### PR TITLE
[이종원 | 0529] 도서 등록 및 수정 기능 구현 (썸네일 업로드 포함) 

### DIFF
--- a/.github/ISSUE_TEMPLATE/todo-템플릿.md
+++ b/.github/ISSUE_TEMPLATE/todo-템플릿.md
@@ -1,0 +1,52 @@
+---
+name: TODO 템플릿
+about: TODO 탬플릿입니다.
+title: ''
+labels: TODO
+assignees: ''
+
+---
+
+### 🧭 작업 이름
+
+- 채널 생성 기능 구현
+
+---
+
+### 🎯 목표
+
+- 서버에 소속된 사용자가 새로운 채널을 생성할 수 있도록 구현
+- 기본적인 유효성 검증 및 DB 저장까지 완료
+
+---
+
+### 📌 작업 항목
+
+- [ ]  API 명세 확인 및 URL 설계 (`POST /api/servers/{serverId}/channels`)
+- [ ]  Request/Response DTO 생성
+- [ ]  Controller 메서드 생성
+- [ ]  Service 비즈니스 로직 작성
+- [ ]  Channel 엔티티 연관관계 설정 확인
+- [ ]  DB 저장 로직 구현
+- [ ]  간단한 테스트 진행 (Postman or Swagger)
+
+---
+
+### 📎 참고사항
+
+- title 필드는 필수, 최대 50자
+- description은 옵션, 255자 이하
+- 인증된 사용자만 생성 가능
+- 같은 서버 내에서 title 중복은 허용 X
+
+---
+
+### 🕒 예상 소요 시간
+
+- 2~3시간
+
+---
+
+### 👤 담당자
+
+- 홍길동 (@honggildong)

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/controller/BookApi.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/controller/BookApi.java
@@ -2,6 +2,7 @@ package com.sprint.deokhugamteam7.domain.book.controller;
 
 import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
 import com.sprint.deokhugamteam7.domain.book.dto.request.BookCreateRequest;
+import com.sprint.deokhugamteam7.domain.book.dto.request.BookUpdateRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.multipart.MultipartFile;
@@ -35,4 +37,33 @@ public interface BookApi {
       )
       MultipartFile file
   );
+
+  @Operation(summary = "Book 수정")
+  @ApiResponses(value = {
+      @ApiResponse(
+          responseCode = "200",
+          description = "Book이 성공적으로 수정됨",
+          content = @Content(schema = @Schema(implementation = BookDto.class)))
+  })
+  ResponseEntity<BookDto> update(
+      @Parameter(
+          description = "도서 ID",
+          required = true
+      )
+      UUID bookId,
+      @Parameter(
+          description = "수정할 도서 정보",
+          required = true,
+          content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+      )
+      BookUpdateRequest request,
+      @Parameter(
+          description = "수정할 도서 썸네일 이미지",
+          content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+      )
+      MultipartFile file
+  );
+
+
+
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/controller/BookController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/controller/BookController.java
@@ -2,12 +2,16 @@ package com.sprint.deokhugamteam7.domain.book.controller;
 
 import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
 import com.sprint.deokhugamteam7.domain.book.dto.request.BookCreateRequest;
+import com.sprint.deokhugamteam7.domain.book.dto.request.BookUpdateRequest;
 import com.sprint.deokhugamteam7.domain.book.service.BookService;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -30,4 +34,16 @@ public class BookController implements BookApi {
 
     return ResponseEntity.status(HttpStatus.CREATED).body(bookDto);
   }
+
+  @PatchMapping("/{bookId}")
+  public ResponseEntity<BookDto> update(
+      @PathVariable UUID bookId,
+      @RequestPart("bookData") BookUpdateRequest request,
+      @RequestPart(value = "thumbnailImage", required = false) MultipartFile file) {
+
+    BookDto bookDto = bookService.update(bookId, request, file);
+
+    return ResponseEntity.ok(bookDto);
+  }
+
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/controller/BookController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/controller/BookController.java
@@ -3,7 +3,9 @@ package com.sprint.deokhugamteam7.domain.book.controller;
 import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
 import com.sprint.deokhugamteam7.domain.book.dto.request.BookCreateRequest;
 import com.sprint.deokhugamteam7.domain.book.service.BookService;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,12 +19,15 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/books")
 public class BookController implements BookApi {
 
-  private BookService bookService;
+  private final BookService bookService;
 
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<BookDto> create(
       @RequestPart("bookData") BookCreateRequest request,
       @RequestPart(value = "thumbnailImage", required = false) MultipartFile file) {
-    return null;
+
+    BookDto bookDto = bookService.create(request, file);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(bookDto);
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/dto/BookDto.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/dto/BookDto.java
@@ -1,11 +1,15 @@
 package com.sprint.deokhugamteam7.domain.book.dto;
 
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
+import lombok.Builder;
 
-
+@Builder
 public record BookDto(
     UUID id,
     String title,
@@ -20,5 +24,27 @@ public record BookDto(
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
+  public static BookDto from(Book book) {
+    List<Review> reviews = book.getReviews();
+    int reviewCount = 0;
+    double rating = 0.0;
+    if (reviews != null) {
+      reviewCount = reviews.size();
+      rating = reviews.stream().mapToDouble(Review::getRating).average().orElse(0.0);
+    }
 
+    return BookDto.builder()
+        .id(book.getId())
+        .title(book.getTitle())
+        .author(book.getAuthor())
+        .description(book.getDescription())
+        .publisher(book.getPublisher())
+        .publishedDate(book.getPublisherDate())
+        .isbn(book.getIsbn())
+        .thumbnailUrl(book.getThumbnailUrl())
+        .createdAt(book.getCreatedAt())
+        .updatedAt(book.getUpdatedAt())
+        .reviewCount(reviewCount)
+        .rating(rating).build();
+  }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/entity/Book.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/entity/Book.java
@@ -1,6 +1,8 @@
 package com.sprint.deokhugamteam7.domain.book.entity;
 
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.exception.DeokhugamException;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -11,11 +13,9 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -43,7 +43,7 @@ public class Book {
   private LocalDateTime updatedAt;
 
   @Column(name = "is_deleted", nullable = false)
-  private Boolean isDeleted;
+  private Boolean isDeleted = false;
 
   @Column(name = "title", nullable = false)
   private String title;
@@ -72,6 +72,9 @@ public class Book {
   @Builder(builderMethodName = "of")
   private Book(String title, String author, String description, String publisher,
       LocalDate publisherDate, String isbn, String thumbnailUrl) {
+    if (title == null | author == null | publisher == null | publisherDate == null) {
+      throw new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
     this.title = title;
     this.author = author;
     this.description = description;

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/entity/Book.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/entity/Book.java
@@ -92,4 +92,22 @@ public class Book {
         .publisher(publisher)
         .publisherDate(publisherDate);
   }
+
+  private String updateField(String original, String newField) {
+    return (newField != null && !newField.equals(original) ? newField : original);
+  }
+
+  private LocalDate updateField(LocalDate original, LocalDate newField) {
+    return (newField != null && !newField.equals(original) ? newField : original);
+  }
+
+  public void update(String newTitle, String newAuthor, String newDescription, String newPublisher,
+      LocalDate newPublisherDate, String newThumbnailUrl) {
+    title = updateField(title, newTitle);
+    author = updateField(author, newAuthor);
+    description = updateField(description, newDescription);
+    publisher = updateField(publisher, newPublisher);
+    publisherDate = updateField(publisherDate, newPublisherDate);
+    thumbnailUrl = updateField(thumbnailUrl, newThumbnailUrl);
+  }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/repository/BookRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookRepository extends JpaRepository<Book, UUID> {
 
+  boolean existsByIsbn(String isbn);
+
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BasicBookService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BasicBookService.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -24,6 +25,7 @@ public class BasicBookService implements BookService{
   private final BookRepository bookRepository;
 
   @Override
+  @Transactional
   public BookDto create(BookCreateRequest request, MultipartFile file) {
     if (bookRepository.existsByIsbn(request.isbn())) {
       throw new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR);
@@ -48,6 +50,7 @@ public class BasicBookService implements BookService{
   }
 
   @Override
+  @Transactional
   public BookDto update(UUID id, BookUpdateRequest request, MultipartFile file) {
     Book book = bookRepository.findById(id).orElseThrow(
         () -> new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BasicBookService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BasicBookService.java
@@ -9,16 +9,11 @@ import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
 import com.sprint.deokhugamteam7.exception.DeokhugamException;
 import com.sprint.deokhugamteam7.exception.ErrorCode;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.core.sync.RequestBody;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Slf4j
 @Service
@@ -54,7 +49,23 @@ public class BasicBookService implements BookService{
 
   @Override
   public BookDto update(UUID id, BookUpdateRequest request, MultipartFile file) {
-    return null;
+    Book book = bookRepository.findById(id).orElseThrow(
+        () -> new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR)
+    );
+
+    String thumbnailUrl = null;
+    if (file != null) {
+      thumbnailUrl = imageService.uploadImage(file);
+    }
+
+    book.update(request.title(), request.author(), request.description(), request.publisher(),
+        request.publishedDate(), thumbnailUrl);
+    bookRepository.save(book);
+
+    log.info("[BasicBookService] update Book : id {}, title {}, created at {}, updated at {}",
+        book.getId(), book.getTitle(), book.getCreatedAt(), book.getUpdatedAt());
+
+    return BookDto.from(book);
   }
 
   @Override

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BasicBookService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BasicBookService.java
@@ -1,14 +1,79 @@
 package com.sprint.deokhugamteam7.domain.book.service;
 
+import com.sprint.deokhugamteam7.domain.book.dto.BookCondition;
+import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
+import com.sprint.deokhugamteam7.domain.book.dto.request.BookCreateRequest;
+import com.sprint.deokhugamteam7.domain.book.dto.request.BookUpdateRequest;
+import com.sprint.deokhugamteam7.domain.book.dto.response.CursorPageResponseBookDto;
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
+import com.sprint.deokhugamteam7.exception.DeokhugamException;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-public class BasicBookService {
+public class BasicBookService implements BookService{
 
-  private BookRepository bookRepository;
+  private final ImageService imageService;
+  private final BookRepository bookRepository;
 
+  @Override
+  public BookDto create(BookCreateRequest request, MultipartFile file) {
+    if (bookRepository.existsByIsbn(request.isbn())) {
+      throw new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    String thumbnailUrl = null;
+    if (file != null) {
+      thumbnailUrl = imageService.uploadImage(file);
+    }
+
+    Book book = Book.create(request.title(), request.author(), request.publisher(),
+            request.publishedDate())
+        .description(request.description())
+        .isbn(request.isbn())
+        .thumbnailUrl(thumbnailUrl).build();
+    bookRepository.save(book);
+
+    log.info("[BasicBookService] create Book : id {}, title {}, created at {}, updated at {}",
+        book.getId(), book.getTitle(), book.getCreatedAt(), book.getUpdatedAt());
+
+    return BookDto.from(book);
+  }
+
+  @Override
+  public BookDto update(UUID id, BookUpdateRequest request, MultipartFile file) {
+    return null;
+  }
+
+  @Override
+  public CursorPageResponseBookDto findAll(BookCondition condition) {
+    return null;
+  }
+
+  @Override
+  public BookDto findById(UUID id) {
+    return null;
+  }
+
+  @Override
+  public void deleteLogically(UUID id) {
+
+  }
+
+  @Override
+  public void deletePhysically(UUID uuid) {
+
+  }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/ImageService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/ImageService.java
@@ -1,5 +1,43 @@
 package com.sprint.deokhugamteam7.domain.book.service;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
 public class ImageService {
 
+  @Value("${aws.s3.bucket}")
+  private String bucketName;
+
+  @Value("${aws.s3.base-url}")
+  private String baseUrl;
+
+  private final S3Client s3Client;
+
+  public String uploadImage(MultipartFile file) {
+    String s3Key = UUID.randomUUID() + "-" + file.getOriginalFilename();
+    String s3Url = baseUrl + "/" + s3Key;
+    PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+        .bucket(bucketName)
+        .key(s3Key)
+        .contentType(file.getContentType())
+        .build();
+    try (InputStream is = file.getInputStream()) {
+      s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(is, file.getSize()));
+    } catch (IOException e) {
+      log.warn("Failed to Upload Image");
+    }
+    return s3Url;
+  }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,4 +26,4 @@ aws:
   region: ${AWS_S3_REGION:ap-northeast-2}
   s3:
     bucket: ${AWS_S3_BUCKET:your-bucket-name}
-    expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600}
+    base-url: ${AWS_S3_BASE_URL:https://your-bucket-name.s3.amazonaws.com}

--- a/src/test/java/com/sprint/deokhugamteam7/BookIntegrationTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/BookIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.sprint.deokhugamteam7;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
+import com.sprint.deokhugamteam7.domain.book.dto.request.BookCreateRequest;
+import com.sprint.deokhugamteam7.domain.book.service.BookService;
+import com.sprint.deokhugamteam7.domain.book.service.ImageService;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class BookIntegrationTest {
+
+  @MockitoBean
+  private ImageService imageService;
+
+  @Autowired
+  private BookService bookService;
+
+  @Test
+  void createBookSuccess_WithNecessaryElement() {
+    // given
+    LocalDate now = LocalDate.now();
+    BookCreateRequest request = new BookCreateRequest("aaa", "bbb", null, "ccc", now, null);
+    // when
+    BookDto bookDto = bookService.create(request, null);
+    // then
+    assertAll(
+        () -> assertThat(bookDto.id()).isNotNull(),
+        () -> assertThat(bookDto.createdAt()).isNotNull(),
+        ()-> assertThat(bookDto.updatedAt()).isNotNull(),
+        () -> assertThat(bookDto.title()).isEqualTo("aaa"),
+        () -> assertThat(bookDto.author()).isEqualTo("bbb"),
+        () -> assertThat(bookDto.publisher()).isEqualTo("ccc"),
+        () -> assertThat(bookDto.publishedDate()).isEqualTo(now)
+    );
+
+  }
+
+}

--- a/src/test/java/com/sprint/deokhugamteam7/BookIntegrationTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/BookIntegrationTest.java
@@ -5,9 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
 import com.sprint.deokhugamteam7.domain.book.dto.request.BookCreateRequest;
+import com.sprint.deokhugamteam7.domain.book.dto.request.BookUpdateRequest;
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
 import com.sprint.deokhugamteam7.domain.book.service.BookService;
 import com.sprint.deokhugamteam7.domain.book.service.ImageService;
 import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,10 +30,22 @@ public class BookIntegrationTest {
   @Autowired
   private BookService bookService;
 
+  @Autowired
+  private BookRepository bookRepository;
+
+  private LocalDate now;
+  private Book testBook;
+
+  @BeforeEach
+  void setUp() {
+    now = LocalDate.now();
+    testBook = Book.create("test111", "test222", "test333", now).build();
+    bookRepository.save(testBook);
+  }
+
   @Test
-  void createBookSuccess_WithNecessaryElement() {
+  void createBookSuccess() {
     // given
-    LocalDate now = LocalDate.now();
     BookCreateRequest request = new BookCreateRequest("aaa", "bbb", null, "ccc", now, null);
     // when
     BookDto bookDto = bookService.create(request, null);
@@ -43,7 +59,26 @@ public class BookIntegrationTest {
         () -> assertThat(bookDto.publisher()).isEqualTo("ccc"),
         () -> assertThat(bookDto.publishedDate()).isEqualTo(now)
     );
+  }
 
+  @Test
+  void updateBookSuccess() {
+    // given
+    LocalDate newDate = LocalDate.now().plusDays(1);
+    BookUpdateRequest request = new BookUpdateRequest("111", "222", "333", "444", newDate);
+    // when
+    BookDto bookDto = bookService.update(testBook.getId(), request, null);
+    // then
+    assertAll(
+        () -> assertThat(bookDto.id()).isNotNull(),
+        () -> assertThat(bookDto.createdAt()).isNotNull(),
+        ()-> assertThat(bookDto.updatedAt()).isNotNull(),
+        () -> assertThat(bookDto.title()).isEqualTo("111"),
+        () -> assertThat(bookDto.author()).isEqualTo("222"),
+        ()-> assertThat(bookDto.description()).isEqualTo("333"),
+        () -> assertThat(bookDto.publisher()).isEqualTo("444"),
+        () -> assertThat(bookDto.publishedDate()).isEqualTo(newDate)
+    );
   }
 
 }

--- a/src/test/java/com/sprint/deokhugamteam7/BookServiceUnitTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/BookServiceUnitTest.java
@@ -1,0 +1,84 @@
+package com.sprint.deokhugamteam7;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
+import com.sprint.deokhugamteam7.domain.book.dto.request.BookCreateRequest;
+import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
+import com.sprint.deokhugamteam7.domain.book.service.BasicBookService;
+import com.sprint.deokhugamteam7.domain.book.service.ImageService;
+import com.sprint.deokhugamteam7.exception.DeokhugamException;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+public class BookServiceUnitTest {
+
+  @Mock
+  private ImageService imageService;
+
+  @Mock
+  private BookRepository bookRepository;
+
+  @InjectMocks
+  private BasicBookService bookService;
+
+  @Test
+  void createBookSuccess_WithNecessaryElement() {
+    // given
+    LocalDate now = LocalDate.now();
+    BookCreateRequest request = new BookCreateRequest("aaa", "bbb", null, "ccc", now, null);
+    // when
+    BookDto bookDto = bookService.create(request, null);
+    // then
+    assertAll(
+        ()->assertThat(bookDto.title()).isEqualTo("aaa"),
+        ()-> assertThat(bookDto.author()).isEqualTo("bbb"),
+        ()-> assertThat(bookDto.publisher()).isEqualTo("ccc"),
+        ()->assertThat(bookDto.publishedDate()).isEqualTo(now)
+    );
+  }
+
+  @Test
+  void createBookSuccess_WithAll() {
+    // given
+    LocalDate now = LocalDate.now();
+    MockMultipartFile mockMultipartFile = new MockMultipartFile("name", "test.png", "image/png",
+        new byte[0]);
+    BookCreateRequest request = new BookCreateRequest("aaa", "bbb", "ccc", "ddd", now, "11111111");
+    when(imageService.uploadImage(mockMultipartFile)).thenReturn("testUrl");
+    // when
+    BookDto bookDto = bookService.create(request, mockMultipartFile);
+    // then
+    assertAll(
+        () -> assertThat(bookDto.title()).isEqualTo("aaa"),
+        () -> assertThat(bookDto.author()).isEqualTo("bbb"),
+        () -> assertThat(bookDto.description()).isEqualTo("ccc"),
+        () -> assertThat(bookDto.publisher()).isEqualTo("ddd"),
+        () -> assertThat(bookDto.publishedDate()).isEqualTo(now),
+        () -> assertThat(bookDto.isbn()).isEqualTo("11111111"),
+        () -> assertThat(bookDto.thumbnailUrl()).isEqualTo("testUrl")
+    );
+  }
+
+  @Test
+  void createBook_WithSameIsbn_ShouldThrowException() {
+    // given
+    BookCreateRequest mock = mock(BookCreateRequest.class);
+    when(mock.isbn()).thenReturn("1234567");
+    when(bookRepository.existsByIsbn("1234567")).thenReturn(false);
+    // when & then
+    assertThrows(DeokhugamException.class, ()->
+        bookService.create(mock, mock(MockMultipartFile.class)));
+  }
+
+}

--- a/src/test/java/com/sprint/deokhugamteam7/BookServiceUnitTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/BookServiceUnitTest.java
@@ -8,11 +8,16 @@ import static org.mockito.Mockito.when;
 
 import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
 import com.sprint.deokhugamteam7.domain.book.dto.request.BookCreateRequest;
+import com.sprint.deokhugamteam7.domain.book.dto.request.BookUpdateRequest;
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
 import com.sprint.deokhugamteam7.domain.book.service.BasicBookService;
 import com.sprint.deokhugamteam7.domain.book.service.ImageService;
 import com.sprint.deokhugamteam7.exception.DeokhugamException;
 import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,11 +36,15 @@ public class BookServiceUnitTest {
 
   @InjectMocks
   private BasicBookService bookService;
+  LocalDate now;
+  @BeforeEach
+  void setUp() {
+    now = LocalDate.now();
+  }
 
   @Test
-  void createBookSuccess_WithNecessaryElement() {
+  void createBook_Success_WithNecessaryElement() {
     // given
-    LocalDate now = LocalDate.now();
     BookCreateRequest request = new BookCreateRequest("aaa", "bbb", null, "ccc", now, null);
     // when
     BookDto bookDto = bookService.create(request, null);
@@ -49,9 +58,8 @@ public class BookServiceUnitTest {
   }
 
   @Test
-  void createBookSuccess_WithAll() {
+  void createBook_Success_WithAll() {
     // given
-    LocalDate now = LocalDate.now();
     MockMultipartFile mockMultipartFile = new MockMultipartFile("name", "test.png", "image/png",
         new byte[0]);
     BookCreateRequest request = new BookCreateRequest("aaa", "bbb", "ccc", "ddd", now, "11111111");
@@ -79,6 +87,27 @@ public class BookServiceUnitTest {
     // when & then
     assertThrows(DeokhugamException.class, ()->
         bookService.create(mock, mock(MockMultipartFile.class)));
+  }
+
+  @Test
+  void updateBook_Success() {
+    // given
+    UUID mock = UUID.randomUUID();
+    LocalDate newDate = LocalDate.now().plusDays(1);
+    Book book = Book.create("aaa", "bbb", "ccc", now).build();
+    BookUpdateRequest request = new BookUpdateRequest("test111", "test222", "test333",
+        "test444", newDate);
+    when(bookRepository.findById(mock)).thenReturn(Optional.of(book));
+    // when
+    BookDto bookDto = bookService.update(mock, request, null);
+    // then
+    assertAll(
+        ()->assertThat(bookDto.title()).isEqualTo("test111"),
+        ()-> assertThat(bookDto.author()).isEqualTo("test222"),
+        ()-> assertThat(bookDto.description()).isEqualTo("test333"),
+        ()-> assertThat(bookDto.publisher()).isEqualTo("test444"),
+        ()->assertThat(bookDto.publishedDate()).isEqualTo(newDate)
+    );
   }
 
 }


### PR DESCRIPTION
🚀 홍보제목
도서 등록 및 수정 기능 포함(썸네일 업로드 포함)

##✨ 개요 (What & Why)

무엇을 구현하는가?
사용자가 책 정보를 입력하고 책을 등록하거나, 기존 책 정보를 저장할 수 있는 기능이 있습니다.
썸네일 이미지를 S3에 업로드하여 도서 썸네일 URL로 생성을 지원하며, MultipartFile 기반의 양식 데이터 요청을 처리합니다.

###왜 이 작업이 필요해요?
도서 관리 시스템에서 도서를 등록/수정하는 기능을 제공하기 추가입니다.
썸네일 이미지 업로드와 ISBN 결합 실험을 포함함으로써, 데이터 정확성과 사용자 환경을 개선합니다.

🔍 주요 변경 사항 (변경된 내용)
북컨트롤러
/api/books POST 구현포인트 구현 (@RequestPart로 MultipartForm 처리)

PATCH /api/books/{bookId} 입체포인트 구현(도서 수정)

기본책서비스
create() 메서드에서 ISBN 검증 및 업로드 처리 추가

update() 메서드에서 조건부 필드 기대 및 S3 이미지가 교체되었습니다.

도서 분리
@builder사용되는 생성자 정의 및 필수 필드 보장

update() 메서드에서 기본 값과 비교 후 변경 필드 적용 (null-safe, 값 동일성 검사)

이미지 서비스
S3 클라이언트를 활용한 이미지 업로드 기능이 있습니다(uploadImage)

파일명 UUID 작성 및 content-type 처리 포함

단위/통합 테스트
BookServiceUnitTest: ISBN 단편, 이미지가 포함되어 있는지 여부에 따라 분기 테스트

BookIntegrationTest: 실제 DB 기반 도서 등록/수정 시뮬레이션 주장

🧩 설계 및 구현 고려사항(Design Decision)
ISBN이 가능해집니다.
데이터베이스 환경이 아닌 공유기에서 공유 여부를 사전에 확인하여, 클라이언트에 대한 뚜렷한 메시지를 전달하고 UX를 복구시킴

이미지 처리 방식
이미지는 필수 값이 아니거나 null 여부에 따라 조건부로 처리
파일명 충돌 방지를 위해 UUID를 두어 할당된 파일명을 S3에 업로드합니다.

도서의 update() 메서드 설계
모든 필드를 null-safe하게 생각하며, 값이 존재하고 있는 경우에만 변경하여 변경 가능하도록
테스트 커버를 제공하는 필드 단위로 유효성을 설계하도록 설계했습니다.

FormData 구조 처리
썸네일을 MultipartFile로 업로드하고 나머지 도서 데이터는 @RequestPart("bookData")를 통해 JSON 형식으로 수신하도록 분리합니다.

✅ 사용자가 테스트하거나 검토할 증상
ISBN 도서 등록 오류 발생 여부 확인

썸네일 이미지를 포함하거나 간략한 상태에서 책 생성 가능 여부

PATCH API를 통해 선택적으로 필드만 변경 가능 여부 확인(부분 업데이트 지원)

🧪 체크리스트
도서 등록 성공(썸네일 포함/생략 케이스)

도서 수정 성공 (모든 필드, 변경 일부 필드 유지)

ISBN 예외 발생 발생

이미지 업로드 동작 여부(Mock 기반 테스트 포함)

현재 AWS S3를 안 열었기 때문에 Book Create랑 업데이트 시 MultiFile 부분은 오류가 날 것입니다. 이점을 누리세요.