### PR TITLE
[최규원 | 0529] 사용자 조회/수정/삭제 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/controller/UserController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/controller/UserController.java
@@ -6,8 +6,11 @@ import com.sprint.deokhugamteam7.domain.user.dto.response.UserDto;
 import com.sprint.deokhugamteam7.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,6 +38,12 @@ public class UserController {
     // 새 세션 생성
     httpRequest.getSession(true).setAttribute("userId", user.id().toString());
 
+    return ResponseEntity.status(200).body(user);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<UserDto> findById(@PathVariable UUID id) {
+    UserDto user = userService.findById(id);
     return ResponseEntity.status(200).body(user);
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/controller/UserController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.sprint.deokhugamteam7.domain.user.controller;
 
 import com.sprint.deokhugamteam7.domain.user.dto.request.UserLoginRequest;
 import com.sprint.deokhugamteam7.domain.user.dto.request.UserRegisterRequest;
+import com.sprint.deokhugamteam7.domain.user.dto.request.UserUpdateRequest;
 import com.sprint.deokhugamteam7.domain.user.dto.response.UserDto;
 import com.sprint.deokhugamteam7.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,6 +11,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,5 +47,12 @@ public class UserController {
   public ResponseEntity<UserDto> findById(@PathVariable UUID id) {
     UserDto user = userService.findById(id);
     return ResponseEntity.status(200).body(user);
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<UserDto> update(@PathVariable UUID id,
+      @Valid @RequestBody UserUpdateRequest request) {
+    UserDto updated = userService.update(id, request);
+    return ResponseEntity.ok(updated);
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/controller/UserController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,5 +55,17 @@ public class UserController {
       @Valid @RequestBody UserUpdateRequest request) {
     UserDto updated = userService.update(id, request);
     return ResponseEntity.ok(updated);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> softDelete(@PathVariable UUID id) {
+    userService.softDeleteById(id);
+    return ResponseEntity.noContent().build();
+  }
+
+  @DeleteMapping("/{id}/hard")
+  public ResponseEntity<Void> hardDelete(@PathVariable UUID id) {
+    userService.hardDeleteById(id);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/dto/request/UserUpdateRequest.java
@@ -1,7 +1,9 @@
 package com.sprint.deokhugamteam7.domain.user.dto.request;
 
+import jakarta.validation.constraints.Size;
+
 public record UserUpdateRequest(
-    String nickname
+    @Size(min = 2, max = 20) String nickname
 ) {
 
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/dto/response/UserDto.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/dto/response/UserDto.java
@@ -7,7 +7,7 @@ public record UserDto(
     UUID id,
     String email,
     String nickname,
-    LocalDateTime createAt
+    LocalDateTime createdAt
 ) {
 
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/entity/User.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/entity/User.java
@@ -38,7 +38,7 @@ public class User {
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
-  private LocalDateTime createAt;
+  private LocalDateTime createdAt;
 
   @LastModifiedDate
   @Column(name = "updated_at")

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImpl.java
@@ -73,7 +73,17 @@ public class UserServiceImpl implements UserService {
   }
 
   public UserDto update(UUID id, UserUpdateRequest request) {
-    return null;
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new UserException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    user.update(request.nickname()); // 닉네임만 변경
+
+    return new UserDto(
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getCreateAt()
+    );
   }
 
   public void softDeleteById(UUID id) {

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImpl.java
@@ -87,8 +87,17 @@ public class UserServiceImpl implements UserService {
   }
 
   public void softDeleteById(UUID id) {
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    user.softDelete();
   }
 
   public void hardDeleteById(UUID id) {
+    if (!userRepository.existsById(id)) {
+      throw new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    userRepository.deleteById(id);
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImpl.java
@@ -39,7 +39,7 @@ public class UserServiceImpl implements UserService {
         savedUser.getId(),
         savedUser.getEmail(),
         savedUser.getNickname(),
-        savedUser.getCreateAt()
+        savedUser.getCreatedAt()
     );
   }
 
@@ -55,7 +55,7 @@ public class UserServiceImpl implements UserService {
         user.getId(),
         user.getEmail(),
         user.getNickname(),
-        user.getCreateAt()
+        user.getCreatedAt()
     );
   }
 
@@ -68,7 +68,7 @@ public class UserServiceImpl implements UserService {
         user.getId(),
         user.getEmail(),
         user.getNickname(),
-        user.getCreateAt()
+        user.getCreatedAt()
     );
   }
 
@@ -82,7 +82,7 @@ public class UserServiceImpl implements UserService {
         user.getId(),
         user.getEmail(),
         user.getNickname(),
-        user.getCreateAt()
+        user.getCreatedAt()
     );
   }
 

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImpl.java
@@ -59,8 +59,17 @@ public class UserServiceImpl implements UserService {
     );
   }
 
+  @Transactional(readOnly = true)
   public UserDto findById(UUID id) {
-    return null;
+    User user = userRepository.findById(id)
+        .orElseThrow(() -> new UserException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    return new UserDto(
+        user.getId(),
+        user.getEmail(),
+        user.getNickname(),
+        user.getCreateAt()
+    );
   }
 
   public UserDto update(UUID id, UserUpdateRequest request) {

--- a/src/test/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/user/service/impl/UserServiceImplTest.java
@@ -2,6 +2,7 @@ package com.sprint.deokhugamteam7.domain.user.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
@@ -11,8 +12,10 @@ import com.sprint.deokhugamteam7.domain.user.dto.response.UserDto;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
 import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
 import com.sprint.deokhugamteam7.exception.DeokhugamException;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
 import com.sprint.deokhugamteam7.exception.user.UserException;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -118,6 +121,36 @@ class UserServiceImplTest {
       assertThat(thrown)
           .isInstanceOf(UserException.class)
           .hasMessage("Internal Server Error");
+    }
+  }
+
+  @Nested
+  @DisplayName("조회")
+  class FindById {
+
+    @Test
+    @DisplayName("조회 성공")
+    void findById_success() {
+      User user = User.create("test@example.com", "tester", "Password123!");
+      when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+
+      UserDto result = userService.findById(user.getId());
+      assertThat(result).isNotNull();
+      assertThat(result.email()).isEqualTo(user.getEmail());
+      assertThat(result.nickname()).isEqualTo(user.getNickname());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 조회 실패")
+    void findById_userNotFound() {
+      UUID userId = UUID.randomUUID();
+      // given
+      when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> userService.findById(userId))
+          .isInstanceOf(UserException.class)
+          .hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
     }
   }
 }


### PR DESCRIPTION
## PR 제목
사용자 조회, 수정, 삭제 기능 구현

---

##  개요
- 사용자 정보를 조회, 수정, 삭제할 수 있는 기능을 구현했습니다.
- 논리 삭제(soft delete)와 물리 삭제(hard delete)를 구분하여 처리합니다.

---

## 🔨 작업 내용
- `UserService.findById(UUID)` 구현
- `UserService.update(UUID, UserUpdateRequest)` 구현
- `UserService.softDeleteById(UUID)` 구현
- `UserService.hardDeleteById(UUID)` 구현
- 컨트롤러에서 각각의 엔드포인트 처리

---

## 테스트 방법
- Postman을 통해 각각의 API 엔드포인트 호출로 확인
- 단위 테스트 (UserServiceImplTest)로 로직 검증

---

Reviewer 참고사항
- 조회/수정/삭제를 나눠서 PR 올리기에는 비효율적인 것 같아서 합쳐서 올렸습니다!