### PR TITLE
[한성태 | 0529] 읽음 상태 단일 수정 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/contoller/NotificationController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/contoller/NotificationController.java
@@ -1,0 +1,33 @@
+package com.sprint.deokhugamteam7.domain.notification.contoller;
+
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
+import com.sprint.deokhugamteam7.domain.notification.service.NotificationService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/notifications")
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @PatchMapping("/{notificationId}")
+    public ResponseEntity<NotificationDto> updateNotification(
+        @PathVariable("notificationId") UUID notificationId,
+        @RequestBody NotificationUpdateRequest request,
+        @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    ) {
+        NotificationDto notificationDto = notificationService.update(notificationId, userId, request);
+        return ResponseEntity.status(HttpStatus.OK).body(notificationDto);
+    }
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/entity/Notification.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/entity/Notification.java
@@ -2,6 +2,8 @@ package com.sprint.deokhugamteam7.domain.notification.entity;
 
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
+import com.sprint.deokhugamteam7.exception.notification.NotificationException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -50,16 +52,29 @@ public class Notification {
   @LastModifiedDate
   private LocalDateTime updated_at;
 
+  // confirmed이 getter 어노테이션으로 인식되지 않음
+  public boolean getConfirmed() {
+    return confirmed;
+  }
+
   private Notification(User user, Review review, String content) {
     this.user = user;
     this.review = review;
     this.content = content;
   }
 
+  public static Notification create(User user, Review review, String content) {
+    return new Notification(user, review, content);
+  }
 
   public void updateConfirmed(boolean confirmed) {
     this.confirmed = confirmed;
   }
 
+  public void validateUserAuthorization(UUID userId) {
+    if (!this.review.getUser().getId().equals(userId)) {
+      throw new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
 
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
@@ -3,8 +3,12 @@ package com.sprint.deokhugamteam7.domain.notification.service.impl;
 import com.sprint.deokhugamteam7.domain.notification.dto.CursorPageResponseNotificationDto;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
+import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
 import com.sprint.deokhugamteam7.domain.notification.repository.NotificationRepository;
 import com.sprint.deokhugamteam7.domain.notification.service.NotificationService;
+import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
+import com.sprint.deokhugamteam7.exception.notification.NotificationException;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +25,29 @@ public class NotificationServiceImpl implements NotificationService {
   @Override
   public NotificationDto update(UUID notificationId, UUID userId,
       NotificationUpdateRequest request) {
-    return null;
+
+    System.out.println(notificationRepository.findAll());
+
+
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    notification.validateUserAuthorization(userId);
+
+    notification.updateConfirmed(request.confirmed());
+
+    NotificationDto result = new NotificationDto(
+        notification.getId(),
+        notification.getUser().getId(),
+        notification.getReview().getId(),
+        notification.getReview().getUser().getNickname(),
+        notification.getContent(),
+        notification.getConfirmed(),
+        notification.getCreated_at(),
+        notification.getUpdated_at()
+    );
+
+    return result;
   }
 
   @Override

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/entity/NotificationTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/entity/NotificationTest.java
@@ -1,0 +1,65 @@
+package com.sprint.deokhugamteam7.domain.notification.entity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
+import com.sprint.deokhugamteam7.exception.notification.NotificationException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class NotificationTest {
+
+    private final UUID NOTIFICATION_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private final UUID OTHER_USER_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+    private User user;
+    private User otherUser;
+    private Review review;
+    private Notification notification;
+
+    @BeforeEach
+    void setup() {
+        user = User.create("test1", "test1", "test1");
+        setPrivateField(user, "id", USER_ID);
+
+        otherUser = User.create("test2", "test2", "test2");
+        setPrivateField(otherUser, "id", OTHER_USER_ID);
+
+        review = new Review();
+        setPrivateField(review, "user", user);
+
+        notification = Notification.create(user, review, "테스트 알림");
+        setPrivateField(notification, "id", NOTIFICATION_ID);
+    }
+
+    @Test
+    @DisplayName("알림 접근 권한 검사 성공 - 작성자와 요청자 일치")
+    void validateUserAuthorization_success() {
+        assertDoesNotThrow(() -> notification.validateUserAuthorization(USER_ID));
+    }
+
+    @Test
+    @DisplayName("알림 접근 권한 검사 실패 - 작성자와 요청자 불일치")
+    void validateUserAuthorization_fail() {
+        assertThatThrownBy(() -> notification.validateUserAuthorization(OTHER_USER_ID))
+            .isInstanceOf(NotificationException.class)
+            .hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+    }
+
+    private void setPrivateField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("리플렉션으로 필드 설정 실패: " + fieldName, e);
+        }
+    }
+
+}

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImplTest.java
@@ -1,0 +1,82 @@
+package com.sprint.deokhugamteam7.domain.notification.service.impl;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
+import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
+import com.sprint.deokhugamteam7.domain.notification.repository.NotificationRepository;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceImplTest {
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    private final UUID NOTIFICATION_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private final UUID OTHER_USER_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+    private User user;
+    private User otherUser;
+    private Review review;
+    private Notification notification;
+
+    @BeforeEach
+    void setup() {
+        user = User.create("test1", "test1", "test1");
+        setPrivateField(user, "id", USER_ID);
+
+        otherUser = User.create("test2", "test2", "test2");
+        setPrivateField(otherUser, "id", OTHER_USER_ID);
+
+        review = new Review();
+        setPrivateField(review, "user", user);
+
+        notification = Notification.create(user, review, "테스트 알림");
+        setPrivateField(notification, "id", NOTIFICATION_ID);
+    }
+
+    @Test
+    @DisplayName("알림 수정 성공 - confirmed 수정 확인")
+    void 알림_수정_성공() {
+        // given
+        NotificationUpdateRequest request = new NotificationUpdateRequest(true);
+
+        given(notificationRepository.findById(any())).willReturn(Optional.of(notification));
+
+        // when
+        NotificationDto result = notificationService.update(NOTIFICATION_ID, USER_ID, request);
+
+        // then
+        assertThat(result.confirmed()).isTrue();
+    }
+
+
+    private void setPrivateField(Object target, String fieldName, Object value) {
+        try {
+            var field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("리플렉션으로 필드 설정 실패: " + fieldName, e);
+        }
+    }
+}


### PR DESCRIPTION
## 🚀 PR 제목

알림 읽음 처리 기능 구현 및 사용자 권한 검증 로직 추가

---

## 📌 개요 (What & Why)

- **무엇을 구현했는가?**  
  사용자가 자신의 알림에 대해 "읽음 처리"할 수 있는 기능을 추가했습니다. 클라이언트는 특정 알림 ID에 대해 읽음 여부(`confirmed`)를 수정 요청할 수 있으며, 해당 요청이 정상적으로 처리되면 수정된 알림 정보를 반환합니다.

- **왜 이 작업이 필요한가?**  
  사용자 경험 상 읽음/읽지 않음 상태 구분은 필수적인 기능입니다. 이를 통해 사용자는 어떤 알림을 이미 확인했는지 직관적으로 관리할 수 있으며, UI에서도 읽음 여부를 시각적으로 표시할 수 있습니다.  
  또한, 보안 측면에서 **알림 수정은 오직 해당 알림의 주인만** 수행할 수 있어야 하므로 사용자 권한 검증 로직이 함께 도입되었습니다.

---

## 🔍 주요 변경 사항 (What was changed)

- `NotificationController`
  - `PATCH /api/notifications/{notificationId}` 엔드포인트 추가
  - `@RequestHeader`로 사용자 ID를 전달받고, 알림 ID 및 수정 요청 본문을 `NotificationService`에 위임

- `NotificationServiceImpl`
  - `update` 메서드 구현
    - 알림 ID로 엔티티 조회
    - 알림 작성자와 요청자 일치 여부 검증 (`validateUserAuthorization`)
    - 읽음 상태(`confirmed`) 업데이트 후 DTO로 응답 반환

- `Notification` 엔티티
  - `validateUserAuthorization(UUID userId)` 메서드 추가
    - 알림에 연결된 리뷰 작성자 ID와 요청자 ID 비교
    - 불일치 시 `NotificationException` 예외 발생
  - 팩토리 메서드 `create` 추가 (사용자, 리뷰, 내용 기반 알림 생성)
  - 상태 수정 메서드 `updateConfirmed` 추가

- `NotificationRepository`
  - 사용자 ID 기준으로 알림을 조회하는 `findAllByUserId(UUID user_id)` 쿼리 메서드 추가

- `NotificationDto`, `NotificationUpdateRequest`
  - API 요청/응답을 위한 DTO 클래스 정의
  - `NotificationDto`는 클라이언트가 필요로 하는 상세 정보 포함 (알림 ID, 사용자 ID, 리뷰 정보, 읽음 상태 등)

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **권한 검증 위치**  
  알림이 특정 사용자에게 귀속된 리소스이므로, 서비스 단에서 명시적으로 사용자 ID를 비교해 권한을 검증했습니다. 알림은 리뷰와 연결되어 있으며, 리뷰의 작성자를 기준으로 권한을 판단합니다.

- **읽음 상태 수정 로직 분리**  
  읽음 상태 변경은 `updateConfirmed()` 메서드를 통해 명확히 의도를 표현하며, 추후 비즈니스 로직이 복잡해질 경우 확장성을 고려해 도메인 메서드로 분리했습니다.

- **예외 설계**  
  사용자 권한 검증 실패 시 명시적인 예외(`NotificationException`)를 발생시키도록 하여, 추후 예외 핸들러에서 일관된 에러 응답을 리턴할 수 있도록 설계했습니다.

- **UUID 기반 식별자 사용**  
  알림, 사용자, 리뷰 등 모든 주요 도메인 객체는 UUID를 식별자로 사용하고 있어, 분산 환경에서도 충돌 없이 안전하게 리소스를 식별할 수 있도록 고려되었습니다.
