### PR TITLE
[#21] [선혜린 | 0529] 리뷰 수정 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/comment/repository/CommentRepository.java
@@ -3,9 +3,13 @@ package com.sprint.deokhugamteam7.domain.comment.repository;
 import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
+  @Query("SELECT COUNT(c) FROM Comment c WHERE c.review.id = :id AND c.isDeleted = false")
+  int countByReviewIdAndIsDeletedFalse(@Param("id") UUID reviewId);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
@@ -1,14 +1,19 @@
 package com.sprint.deokhugamteam7.domain.review.controller;
 
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
 import com.sprint.deokhugamteam7.domain.review.service.ReviewService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,5 +30,14 @@ public class ReviewController {
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(reviewDto);
+  }
+
+  @PatchMapping(path = "/{reviewId}")
+  public ResponseEntity<ReviewDto> update(
+      @PathVariable() UUID reviewId,
+      @RequestHeader(value = "Deokhugam-Request-User-ID") UUID userId,
+      @RequestBody @Valid ReviewUpdateRequest request) {
+    ReviewDto reviewDto = reviewService.update(reviewId, userId, request);
+    return ResponseEntity.ok(reviewDto);
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/request/ReviewUpdateRequest.java
@@ -1,7 +1,12 @@
 package com.sprint.deokhugamteam7.domain.review.dto.request;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
 public record ReviewUpdateRequest(
-    String content,
+    @NotBlank String content,
+    @Min(1) @Max(5)
     int rating
 ) {
 

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/response/ReviewDto.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/response/ReviewDto.java
@@ -1,8 +1,6 @@
 package com.sprint.deokhugamteam7.domain.review.dto.response;
 
-import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
-import com.sprint.deokhugamteam7.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Builder;
@@ -24,15 +22,15 @@ public record ReviewDto(
     LocalDateTime updatedAt
 ) {
 
-  public static ReviewDto of(Book book, User user, Review review, int likeCount, int commentCount,
+  public static ReviewDto of(Review review, int likeCount, int commentCount,
       boolean likedByMe) {
     return ReviewDto.builder()
         .id(review.getId())
-        .bookId(book.getId())
-        .bookTitle(book.getTitle())
-        .bookThumbnailUrl(book.getThumbnailUrl())
-        .userId(user.getId())
-        .userNickname(user.getNickname())
+        .bookId(review.getBook().getId())
+        .bookTitle(review.getBook().getTitle())
+        .bookThumbnailUrl(review.getBook().getThumbnailUrl())
+        .userId(review.getUser().getId())
+        .userNickname(review.getUser().getNickname())
         .content(review.getContent())
         .rating(review.getRating())
         .likeCount(likeCount)

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/Review.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/Review.java
@@ -4,6 +4,8 @@ package com.sprint.deokhugamteam7.domain.review.entity;
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
+import com.sprint.deokhugamteam7.exception.review.ReviewException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -61,6 +63,7 @@ public class Review {
   @Column(updatable = false)
   private LocalDateTime updatedAt;
 
+  // 두 List가 필요없다는게 확인 됨. 그래도 혹시 모르니, 기능 구현이 끝나기 전까진 놔둘 예정.
   @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Comment> commentList;
 
@@ -92,5 +95,16 @@ public class Review {
 
   public void delete() {
     isDeleted = true;
+  }
+
+  public void update(String content, int rating) {
+    this.content = content;
+    this.rating = rating;
+  }
+
+  public void validateUserAuthorization(UUID userId) {
+    if (!this.user.getId().equals(userId)) {
+      throw new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepository.java
@@ -1,9 +1,17 @@
 package com.sprint.deokhugamteam7.domain.review.repository;
 
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
+  @Query("SELECT r FROM Review r "
+      + "JOIN FETCH r.user "
+      + "JOIN FETCH r.book"
+      + " WHERE r.id = :id")
+  Optional<Review> findByIdWithUserAndBook(@Param("id") UUID id);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
@@ -1,19 +1,16 @@
 package com.sprint.deokhugamteam7.domain.review.service;
 
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
-import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
-import com.sprint.deokhugamteam7.domain.review.dto.response.CursorPageResponseReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
 import java.util.UUID;
 
 public interface ReviewService {
 
   ReviewDto create(ReviewCreateRequest request);
+
+  ReviewDto update(UUID id, UUID userId, ReviewUpdateRequest request);
 /*
-
-  ReviewDto update(ReviewUpdateRequest request);
-
   void deleteLogically(UUID id, UUID userId);
 
   void deletePhysically(UUID id, UUID userId);

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
@@ -2,9 +2,12 @@ package com.sprint.deokhugamteam7.domain.review.service.basic;
 
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
+import com.sprint.deokhugamteam7.domain.comment.repository.CommentRepository;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.review.repository.ReviewLikeRepository;
 import com.sprint.deokhugamteam7.domain.review.repository.ReviewRepository;
 import com.sprint.deokhugamteam7.domain.review.service.ReviewService;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
@@ -23,6 +26,8 @@ public class BasicReviewService implements ReviewService {
   private final ReviewRepository reviewRepository;
   private final UserRepository userRepository;
   private final BookRepository bookRepository;
+  private final ReviewLikeRepository reviewLikeRepository;
+  private final CommentRepository commentRepository;
 
   @Override
   @Transactional
@@ -38,6 +43,33 @@ public class BasicReviewService implements ReviewService {
     Review review = Review.create(book, user, request.content(), request.rating());
     reviewRepository.save(review);
 
-    return ReviewDto.of(book, user, review, 0, 0, false);
+    return ReviewDto.of(review, 0, 0, false);
+  }
+
+  @Override
+  @Transactional
+  public ReviewDto update(UUID id, UUID userId, ReviewUpdateRequest request) {
+    if (!userRepository.existsById(userId)) {
+      throw new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+    Review review = reviewRepository.findByIdWithUserAndBook(id)
+        .orElseThrow(() -> new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    review.validateUserAuthorization(userId);
+
+    if (review.getUser().isDeleted() || review.getBook().getIsDeleted()) {
+      throw new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    String newContent = request.content();
+    int newRating = request.rating();
+
+    review.update(newContent, newRating);
+
+    int likeCount = reviewLikeRepository.countByReviewId(id);
+    int commentCount = commentRepository.countByReviewIdAndIsDeletedFalse(id);
+    boolean likedByMe = reviewLikeRepository.existsByUserIdAndReviewId(userId, id);
+
+    return ReviewDto.of(review, likeCount, commentCount, likedByMe);
   }
 }

--- a/src/test/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewServiceTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewServiceTest.java
@@ -5,8 +5,12 @@ import static org.mockito.Mockito.when;
 
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
+import com.sprint.deokhugamteam7.domain.comment.repository.CommentRepository;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.review.repository.ReviewLikeRepository;
 import com.sprint.deokhugamteam7.domain.review.repository.ReviewRepository;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
 import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
@@ -20,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class BasicReviewServiceTest {
@@ -32,6 +37,12 @@ public class BasicReviewServiceTest {
 
   @Mock
   private BookRepository bookRepository;
+
+  @Mock
+  private ReviewLikeRepository reviewLikeRepository;
+
+  @Mock
+  private CommentRepository commentRepository;
 
   @InjectMocks
   private BasicReviewService reviewService;
@@ -53,14 +64,16 @@ public class BasicReviewServiceTest {
         LocalDate.of(2020, 1, 15)
     ).build();
 
-    when(userRepository.findByIdAndIsDeletedFalse(userId)).thenReturn(Optional.of(user));
-    when(bookRepository.findByIdAndIsDeletedFalse(bookId)).thenReturn(Optional.of(book));
+    ReflectionTestUtils.setField(user, "id", userId);
+    ReflectionTestUtils.setField(book, "id", bookId);
   }
 
   @Test
   @DisplayName("리뷰 생성")
   void createReview() {
     // given
+    when(userRepository.findByIdAndIsDeletedFalse(userId)).thenReturn(Optional.of(user));
+    when(bookRepository.findByIdAndIsDeletedFalse(bookId)).thenReturn(Optional.of(book));
     ReviewCreateRequest request
         = new ReviewCreateRequest(bookId, userId, "책의 리뷰입니다.", 3);
 
@@ -71,5 +84,35 @@ public class BasicReviewServiceTest {
     assertThat(result).isNotNull();
     assertThat(result.content()).isEqualTo("책의 리뷰입니다.");
     assertThat(result.rating()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("리뷰 수정 - 성공")
+  void updateReview_Success() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    Review review = Review.create(book, user, "책의 리뷰입니다.", 3);
+    ReflectionTestUtils.setField(review, "id", reviewId);
+    ReviewUpdateRequest request
+        = new ReviewUpdateRequest("리뷰 변경합니다.", 5);
+
+    when(userRepository.existsById(userId)).thenReturn(true);
+    when(reviewRepository.findByIdWithUserAndBook(reviewId)).thenReturn(Optional.of(review));
+    when(reviewLikeRepository.countByReviewId(reviewId)).thenReturn(2);
+    when(commentRepository.countByReviewIdAndIsDeletedFalse(reviewId)).thenReturn(4);
+    when(reviewLikeRepository.existsByUserIdAndReviewId(userId, reviewId)).thenReturn(true);
+
+    // when
+    ReviewDto result = reviewService.update(reviewId, userId, request);
+
+    // then
+    ReviewDto expectedDto = ReviewDto.of(review, 2, 4, true);
+
+    assertThat(expectedDto.id()).isEqualTo(result.id());
+    assertThat(expectedDto.content()).isEqualTo(result.content());
+    assertThat(expectedDto.rating()).isEqualTo(result.rating());
+    assertThat(expectedDto.likeCount()).isEqualTo(result.likeCount());
+    assertThat(expectedDto.commentCount()).isEqualTo(result.commentCount());
+    assertThat(expectedDto.likedByMe()).isEqualTo(result.likedByMe());
   }
 }


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?
사용자가 작성한 리뷰를 수정할 수 있는 기능을 구현했습니다. 리뷰의 내용과 평점을 변경할 수 있으며, 응답에는 최신 상태의 좋아요 수, 댓글 수, 본인이 좋아요를 눌렀는지 여부 등의 메타 정보도 함께 제공합니다.

왜 이 작업이 필요한가?
리뷰는 시간의 흐름에 따라 사용자의 의견이 달라질 수 있는 콘텐츠입니다. 따라서 수정 기능은 리뷰 시스템에서 필수적인 기능이며, 사용자 편의성과 시스템 완성도를 높이는 데 중요한 역할을 합니다.
또한, 본인이 작성한 리뷰만 수정 가능하도록 권한 검증을 추가하여 보안성과 데이터 무결성을 보장합니다.

🔍 주요 변경 사항 (What was changed)
BasicReviewService#update:
- 리뷰 ID 및 사용자 ID 기반으로 리뷰를 조회하고, 작성자 본인 여부를 검증
- 논리적으로 삭제된 사용자 또는 도서에 대한 리뷰는 수정 불가 처리
- 리뷰 객체의 update() 메서드를 통해 내용과 평점을 갱신
- 수정 후 최신 리뷰 상태를 ReviewDto로 변환하여 반환
- 좋아요 수, 댓글 수, 본인 좋아요 여부도 함께 계산하여 응답

Review#validateUserAuthorization:
- 리뷰 작성자 ID와 요청자의 ID를 비교하여 권한이 없는 경우 예외 발생

ReviewRepository#findByIdWithUserAndBook:
- 리뷰 수정 시 필요한 사용자 및 도서 정보까지 함께 조회하기 위한 JPQL 작성

ReviewLikeRepository:
- 특정 리뷰에 대한 좋아요 개수 및 사용자의 좋아요 여부 판단 메서드 정의

CommentRepository:
- 삭제되지 않은 댓글만 집계하여 정확한 댓글 수 반환

🧩 설계 및 구현 고려사항 (Design decisions)
권한 검증 위치와 방식
리뷰 객체 내부의 validateUserAuthorization() 메서드를 통해 도메인 주도 설계 관점에서 권한 체크를 캡슐화했습니다. 서비스 계층에서 리뷰 객체를 가져온 후 도메인 로직에 위임하여 작성자 본인만 수정할 수 있도록 했습니다.

삭제된 사용자/도서에 대한 검증
리뷰 수정 시 연관된 사용자나 도서가 논리적으로 삭제된 경우 예외를 발생시킴으로써, 존재하지 않거나 유효하지 않은 객체에 대한 접근을 방지했습니다.

정확한 응답 데이터 제공
클라이언트 측에서 최신 상태의 리뷰를 바로 반영할 수 있도록, 수정 직후의 좋아요 수, 댓글 수, 좋아요 여부를 포함한 ReviewDto를 응답하도록 하여 사용자 경험을 개선했습니다.

성능을 고려한 fetch 전략
리뷰 조회 시 사용자 및 도서 객체를 함께 조회(Fetch Join)하여 N+1 문제를 방지하고, 이후의 유효성 검증 및 DTO 매핑 시 성능 저하를 방지했습니다.

- 테스트 작성
: 단위테스트 작성

close #21 