### PR TITLE
[#29] [선혜린 | 0529] 리뷰 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,5 +40,21 @@ public class ReviewController {
       @RequestBody @Valid ReviewUpdateRequest request) {
     ReviewDto reviewDto = reviewService.update(reviewId, userId, request);
     return ResponseEntity.ok(reviewDto);
+  }
+
+  @DeleteMapping(path = "/{reviewId}")
+  public ResponseEntity<Void> deleteSoft(
+      @PathVariable UUID reviewId,
+      @RequestHeader(value = "Deokhugam-Request-User-ID") UUID userId) {
+    reviewService.deleteSoft(reviewId, userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  @DeleteMapping(path = "/{reviewId}/hard")
+  public ResponseEntity<Void> deleteHard(
+      @PathVariable UUID reviewId,
+      @RequestHeader(value = "Deokhugam-Request-User-ID") UUID userId) {
+    reviewService.deleteHard(reviewId, userId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
@@ -10,11 +10,11 @@ public interface ReviewService {
   ReviewDto create(ReviewCreateRequest request);
 
   ReviewDto update(UUID id, UUID userId, ReviewUpdateRequest request);
+
+  void deleteSoft(UUID id, UUID userId);
+
+  void deleteHard(UUID id, UUID userId);
 /*
-  void deleteLogically(UUID id, UUID userId);
-
-  void deletePhysically(UUID id, UUID userId);
-
   CursorPageResponseReviewDto findReviews(ReviewSearchCondition condition);
 */
 

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
@@ -72,4 +72,26 @@ public class BasicReviewService implements ReviewService {
 
     return ReviewDto.of(review, likeCount, commentCount, likedByMe);
   }
+
+  @Override
+  @Transactional(readOnly = true)
+  public void deleteSoft(UUID id, UUID userId) {
+    Review review = reviewRepository.findById(id)
+        .orElseThrow(() -> new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    review.validateUserAuthorization(userId);
+
+    review.delete();
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public void deleteHard(UUID id, UUID userId) {
+    Review review = reviewRepository.findById(id)
+        .orElseThrow(() -> new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    review.validateUserAuthorization(userId);
+
+    reviewRepository.delete(review);
+  }
 }

--- a/src/test/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewServiceTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewServiceTest.java
@@ -115,4 +115,36 @@ public class BasicReviewServiceTest {
     assertThat(expectedDto.commentCount()).isEqualTo(result.commentCount());
     assertThat(expectedDto.likedByMe()).isEqualTo(result.likedByMe());
   }
+  
+  @Test
+  @DisplayName("리뷰 삭제 - Soft")
+  void updateReview_Soft() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    Review review = Review.create(book, user, "책의 리뷰입니다.", 3);
+    ReflectionTestUtils.setField(review, "id", reviewId);
+
+    when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
+
+    // when
+    reviewService.deleteSoft(reviewId, userId);
+
+    assertThat(review.getIsDeleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("리뷰 삭제 - Hard")
+  void updateReview_Hard() {
+    // given
+    UUID reviewId = UUID.randomUUID();
+    Review review = Review.create(book, user, "책의 리뷰입니다.", 3);
+    ReflectionTestUtils.setField(review, "id", reviewId);
+
+    when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
+
+    // when
+    reviewService.deleteHard(reviewId, userId);
+
+    assertThat(reviewRepository.existsById(reviewId)).isFalse();
+  }
 }


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?
사용자가 자신의 리뷰를 삭제할 수 있도록 소프트 삭제와 하드 삭제 기능을 각각 구현하였습니다. 소프트 삭제는 데이터베이스에 리뷰 데이터를 남기되 isDeleted 플래그를 변경하며, 하드 삭제는 리뷰 레코드를 영구 제거합니다.

왜 이 작업이 필요한가?
리뷰는 사용자 생성 콘텐츠(UGC)로, 사용자가 작성 후 언제든 삭제할 수 있어야 합니다. 소프트 삭제는 데이터 복구 및 감사 로그를 위한 보존이 필요한 경우에 유용하며, 하드 삭제는 완전한 제거가 필요한 관리 목적 등에 사용됩니다.
또한, 삭제 권한은 작성자 본인에게만 부여되어야 하므로, 보안성과 무결성 유지를 위해 권한 검증 로직을 함께 추가했습니다.

🔍 주요 변경 사항 (What was changed)
BasicReviewService#deleteSoft:
- 리뷰 ID 기준으로 리뷰 조회 후, 작성자 권한 확인
- review.delete() 호출을 통해 논리 삭제 (isDeleted 플래그 true 처리)

BasicReviewService#deleteHard:
- 리뷰 ID 기준으로 리뷰 조회 후, 작성자 권한 확인
- reviewRepository.delete(...)를 통해 영구 삭제 수행

ReviewController:
- DELETE /{reviewId}: 소프트 삭제 요청 처리
- DELETE /{reviewId}/hard: 하드 삭제 요청 처리

두 메서드 모두 요청자 ID를 Deokhugam-Request-User-ID 헤더에서 전달받아 검증 수행

🧩 설계 및 구현 고려사항 (Design decisions)
소프트 삭제 vs 하드 삭제 분리 이유
서로 다른 삭제 정책을 클라이언트가 명시적으로 선택할 수 있도록, URL 경로를 분기(/hard)하여 기능을 명확히 구분했습니다. 이로 인해 사용성과 가독성이 향상되며, API 명세에서도 명확한 의도를 표현할 수 있습니다.

도메인 권한 검증 방식
Review 객체의 validateUserAuthorization() 메서드를 통해 삭제 권한을 검증합니다. 도메인 내부에서 권한 로직을 위임함으로써 서비스 계층은 비즈니스 흐름에 집중할 수 있게 되었고, 책임이 명확하게 분리됩니다.

트랜잭션 설정 전략
삭제 동작이지만, 내부적으로 review만 수정하거나 제거할 뿐 외부 연관 테이블에 영향을 주지 않기 때문에 @Transactional(readOnly = true)를 유지했습니다. 필요시 readOnly = false로 조정 가능합니다.

헤더 기반 사용자 식별 처리
사용자 ID를 요청 헤더(Deokhugam-Request-User-ID)에서 받아 처리하도록 구성하여, 인증 처리와 사용자 식별을 명확하게 분리하였고 향후 보안 헤더/인증 토큰 기반 연동이 가능하도록 고려된 설계입니다.

