### PR TITLE
[한성태 | 0529] 알림 전체 읽음 상태 수정 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/contoller/NotificationController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/contoller/NotificationController.java
@@ -22,12 +22,20 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @PatchMapping("/{notificationId}")
-    public ResponseEntity<NotificationDto> updateNotification(
+    public ResponseEntity<NotificationDto> update(
         @PathVariable("notificationId") UUID notificationId,
         @RequestBody NotificationUpdateRequest request,
         @RequestHeader("Deokhugam-Request-User-ID") UUID userId
     ) {
         NotificationDto notificationDto = notificationService.update(notificationId, userId, request);
         return ResponseEntity.status(HttpStatus.OK).body(notificationDto);
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<Void> updateAll(
+        @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    ) {
+        notificationService.updateAll(userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/dto/NotificationDto.java
@@ -1,5 +1,6 @@
 package com.sprint.deokhugamteam7.domain.notification.dto;
 
+import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -13,5 +14,16 @@ public record NotificationDto(
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
-
+    public static NotificationDto fromEntity(Notification notification) {
+        return new NotificationDto(
+            notification.getId(),
+            notification.getUser().getId(),
+            notification.getReview().getId(),
+            notification.getReview().getUser().getNickname(), // review 작성자의 닉네임이 title로 사용됨
+            notification.getContent(),
+            notification.getConfirmed(),
+            notification.getCreated_at(),
+            notification.getUpdated_at()
+        );
+    }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/entity/Notification.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/entity/Notification.java
@@ -6,9 +6,13 @@ import com.sprint.deokhugamteam7.exception.ErrorCode;
 import com.sprint.deokhugamteam7.exception.notification.NotificationException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -19,10 +23,12 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Table(name = "notifications")
 @Getter
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor
 @AllArgsConstructor
 public class Notification {
@@ -31,10 +37,12 @@ public class Notification {
   @GeneratedValue(strategy = GenerationType.UUID)
   private UUID id;
 
-  @OneToOne
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
   private User user;
 
-  @OneToOne
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "review_id")
   private Review review;
 
   private String content;

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepository.java
@@ -4,6 +4,7 @@ import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -13,6 +14,10 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   @Query("SELECT n FROM Notification n "
       + "JOIN FETCH n.user u "
       + "JOIN FETCH n.review r "
-      + "WHERE n.user.id = :user_id")
-  List<Notification> findAllByUserId(UUID user_id);
+      + "WHERE n.review.user.id = :user_id AND n.isDelete = false ")
+  List<Notification> findAllByReviewerId(UUID user_id);
+
+  @Modifying
+  @Query("UPDATE Notification n SET n.confirmed = true WHERE n.review.user.id = :user_id")
+  void bulkUpdateConfirmed(UUID user_id);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/NotificationService.java
@@ -10,7 +10,7 @@ public interface NotificationService {
 
   NotificationDto update(UUID notificationId, UUID userId, NotificationUpdateRequest request);
 
-  List<NotificationDto> updateAll(UUID userId);
+  void updateAll(UUID userId);
 
   CursorPageResponseNotificationDto findAll(UUID userId);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
@@ -9,6 +9,7 @@ import com.sprint.deokhugamteam7.domain.notification.service.NotificationService
 import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
 import com.sprint.deokhugamteam7.exception.ErrorCode;
 import com.sprint.deokhugamteam7.exception.notification.NotificationException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +22,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationServiceImpl implements NotificationService {
 
   private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
 
   @Override
   public NotificationDto update(UUID notificationId, UUID userId,
       NotificationUpdateRequest request) {
-
-    System.out.println(notificationRepository.findAll());
-
 
     Notification notification = notificationRepository.findById(notificationId)
         .orElseThrow(() -> new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR));
@@ -36,30 +35,22 @@ public class NotificationServiceImpl implements NotificationService {
 
     notification.updateConfirmed(request.confirmed());
 
-    NotificationDto result = new NotificationDto(
-        notification.getId(),
-        notification.getUser().getId(),
-        notification.getReview().getId(),
-        notification.getReview().getUser().getNickname(),
-        notification.getContent(),
-        notification.getConfirmed(),
-        notification.getCreated_at(),
-        notification.getUpdated_at()
-    );
+    NotificationDto result = NotificationDto.fromEntity(notification);
 
     return result;
   }
 
   @Override
-  public List<NotificationDto> updateAll(UUID userId) {
-    notificationRepository.findAllByUserId(userId);
-    return List.of();
+  public void updateAll(UUID userId) {
+    userRepository.findById(userId)
+        .orElseThrow(() -> new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR));
+    notificationRepository.bulkUpdateConfirmed(userId);
   }
 
   @Override
   @Transactional(readOnly = true)
   public CursorPageResponseNotificationDto findAll(UUID userId) {
-    notificationRepository.findAllByUserId(userId);
+    notificationRepository.findAllByReviewerId(userId);
     return null;
   }
 

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.sprint.deokhugamteam7.domain.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sprint.deokhugamteam7.config.AppConfig;
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Import(value = AppConfig.class)
+@Transactional
+class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private User user;
+    private User reviewer;
+    private Review review;
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+        // 유저 생성
+        user = User.create("test1", "test1", "test1");
+        reviewer = User.create("test2", "test2", "test2");
+        book = Book.create("test", "test", "???", LocalDate.now()).build();
+
+        em.persist(user);
+        em.persist(reviewer);
+        em.persist(book);
+
+        // 리뷰 생성
+        review = Review.create(book, reviewer, "test", 5);
+        em.persist(review);
+
+        for (int i = 0; i < 3; i++) {
+            Notification n = Notification.create(user, review, "알림 내용 " + i);
+            em.persist(n);
+        }
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    void findAllByUserId_성공() {
+        List<Notification> notifications = notificationRepository.findAllByReviewerId(reviewer.getId());
+
+        assertThat(notifications).hasSize(3);
+        assertThat(notifications).allMatch(n -> n.getReview().getUser().getId().equals(reviewer.getId()));
+    }
+
+    @Test
+    void bulkUpdateConfirmed_성공() {
+
+        List<Notification> beforeUpdate = notificationRepository.findAllByReviewerId(reviewer.getId());
+        assertThat(beforeUpdate).allMatch(n -> !n.getConfirmed());
+
+        notificationRepository.bulkUpdateConfirmed(reviewer.getId());
+        em.flush();
+        em.clear();
+
+        List<Notification> afterUpdate = notificationRepository.findAllByReviewerId(reviewer.getId());
+        assertThat(afterUpdate).allMatch(Notification::getConfirmed);
+    }
+}


### PR DESCRIPTION
## 🚀 PR 제목

알림 전체 읽음 처리 기능 테스트 및 리팩토링: Notification 연관관계 수정 및 일괄 업데이트 쿼리 검증

---

## 📌 개요 (What & Why)

- **무엇을 구현했는가?**  
  사용자가 받은 알림을 한 번에 읽음 처리할 수 있는 기능의 일괄 업데이트 로직을 도입하고, 관련 테스트를 통해 이 기능의 정확성을 검증했습니다.  
  또한 `Notification` 엔티티의 연관관계 설계 오류를 수정하여 `User`, `Review`와의 관계를 `OneToOne`에서 `ManyToOne`으로 변경했습니다.

- **왜 이 작업이 필요한가?**  
  알림은 하나의 유저나 리뷰에 대해 여러 개가 존재할 수 있기 때문에, `OneToOne` 관계는 실제 비즈니스 모델을 반영하지 못합니다. 이를 `ManyToOne`으로 수정하여 다대일 관계를 표현했고, 전체 알림을 읽음 처리하는 로직에 대해 통합 테스트를 통해 검증을 수행했습니다.

---

## 🔍 주요 변경 사항 (What was changed)

- **`NotificationRepositoryTest`**
  - `findAllByUserId_성공()`: 특정 리뷰어가 받은 알림 목록 조회 테스트
  - `bulkUpdateConfirmed_성공()`: 알림 전체 읽음 처리 기능 테스트
  - 테스트를 위한 `User`, `Review`, `Book`, `Notification` 데이터 생성 로직 추가

- **`Notification` 엔티티**
  - `user` 및 `review`와의 관계를 `@OneToOne` → `@ManyToOne`으로 수정
  - `create()` 정적 팩토리 메서드 추가
  - 사용자 권한 검증 메서드 `validateUserAuthorization()` 추가

- **`NotificationRepository`**
  - `findAllByReviewerId(UUID userId)`: 리뷰 작성자 기준 알림 목록 조회 JPQL 정의
  - `bulkUpdateConfirmed(UUID userId)`: 알림 확인 여부를 일괄 true로 업데이트하는 쿼리 추가

- **`NotificationService`**
  - `updateAll(UUID userId)`: 알림 전체 읽음 처리 서비스 구현
  - 예외 처리 및 존재 여부 확인 로직 포함

- **`NotificationController`**
  - `@PatchMapping("/read-all")`: 사용자 ID를 헤더에서 받아 전체 알림을 읽음 처리하는 API 추가

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **알림의 다대일 관계 설계**
  - 하나의 리뷰에 대해 여러 알림이 생성될 수 있고, 하나의 유저가 여러 알림을 받을 수 있는 구조를 고려해 기존의 `@OneToOne` 관계를 `@ManyToOne`으로 수정했습니다. 이는 JPA 설계상 올바른 방향이며, `unique` 제약을 제거함으로써 실 데이터 구조에 맞게 수정한 것입니다.

- **읽음 처리 일괄 업데이트**
  - `Notification`은 사용자 기준으로 자주 접근되므로, 리뷰 작성자 ID 기준으로 `bulk update` 쿼리를 정의해 성능을 고려했습니다.
  - 개별 업데이트보다 효율적인 일괄 처리 방식을 채택하여, 알림 수가 많아져도 성능 저하 없이 처리 가능하게 설계했습니다.

- **서비스 레이어 예외 처리**
  - `userRepository.findById()`를 통해 알림 대상 사용자의 존재 여부를 확인하고, 존재하지 않으면 `NotificationException`을 발생시킵니다.
  - 이는 불필요한 업데이트 시도를 방지하고, API의 신뢰성을 보장합니다.
