### PR TITLE
[#31 | 선혜린 | 0530] 리뷰 좋아요 기능

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.sprint.deokhugamteam7.domain.review.controller;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
+import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewLikeDto;
 import com.sprint.deokhugamteam7.domain.review.service.ReviewService;
 import jakarta.validation.Valid;
 import java.util.UUID;
@@ -56,5 +57,15 @@ public class ReviewController {
       @RequestHeader(value = "Deokhugam-Request-User-ID") UUID userId) {
     reviewService.deleteHard(reviewId, userId);
     return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping(path = "/{reviewId}/like")
+  public ResponseEntity<ReviewLikeDto> like(
+      @PathVariable UUID reviewId,
+      @RequestHeader(value = "Deokhugam-Request-User-ID") UUID userId) {
+    ReviewLikeDto reviewLikeDto = reviewService.like(reviewId, userId);
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(reviewLikeDto);
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewLikeRepository.java
@@ -1,6 +1,7 @@
 package com.sprint.deokhugamteam7.domain.review.repository;
 
 import com.sprint.deokhugamteam7.domain.review.entity.ReviewLike;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,6 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID> {
       + "FROM ReviewLike rl "
       + "WHERE rl.user.id = :userId AND rl.review.id = :reviewId")
   boolean existsByUserIdAndReviewId(@Param("userId") UUID userId, @Param("reviewId") UUID reviewId);
+
+  Optional<ReviewLike> findByReviewIdAndUserId(UUID reviewId, UUID userId);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.sprint.deokhugamteam7.domain.review.service;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
+import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewLikeDto;
 import java.util.UUID;
 
 public interface ReviewService {
@@ -14,6 +15,8 @@ public interface ReviewService {
   void deleteSoft(UUID id, UUID userId);
 
   void deleteHard(UUID id, UUID userId);
+
+  ReviewLikeDto like(UUID id, UUID userId);
 /*
   CursorPageResponseReviewDto findReviews(ReviewSearchCondition condition);
 */


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?
사용자가 특정 리뷰에 대해 좋아요를 누르거나 취소할 수 있는 기능을 구현했습니다. 좋아요는 토글 방식으로 작동하며, 기존에 좋아요를 누른 상태라면 취소되고, 누르지 않았다면 등록됩니다.

왜 이 작업이 필요한가?
좋아요 기능은 사용자 피드백을 수집하고, 콘텐츠에 대한 반응을 시각적으로 드러내는 핵심적인 UX 요소입니다. 리뷰에 대한 선호도를 반영하고, 향후 정렬·추천 등의 기능에 활용될 수 있는 데이터 기반을 마련하기 위해 필요합니다.

🔍 주요 변경 사항 (What was changed)
ReviewController#like:
- POST /{reviewId}/like 경로를 통해 좋아요 요청을 처리
- 사용자 ID는 요청 헤더(Deokhugam-Request-User-ID)를 통해 전달받음
- 성공 시 201 Created 상태와 함께 ReviewLikeDto 반환

BasicReviewService#like:
- 사용자와 리뷰의 존재 여부를 검증
- ReviewLikeRepository를 통해 해당 유저가 이미 좋아요를 눌렀는지 확인
- 존재하면 좋아요 취소 (delete), 존재하지 않으면 등록 (save)
- 최종 좋아요 상태를 담은 DTO(ReviewLikeDto) 반환

ReviewLikeDto:
- 리뷰 ID, 사용자 ID, 현재 좋아요 여부(liked)를 포함하는 응답 DTO 구성

🧩 설계 및 구현 고려사항 (Design decisions)
토글 방식 설계 이유
좋아요는 일반적으로 단순한 클릭 동작에 의해 상태가 전환되는 UX를 가지므로, 별도의 상태 확인 API 없이도 토글 처리 방식으로 구현하여 클라이언트와의 통신을 간소화했습니다.

권한 및 유효성 검증
userRepository와 reviewRepository를 통해 존재 검증을 명시적으로 수행함으로써, 삭제되었거나 잘못된 ID에 대한 예외 상황을 안전하게 처리할 수 있도록 했습니다.

비즈니스 로직 분기 처리
좋아요 여부는 ReviewLike 엔티티 존재 여부에 따라 판단하고, 이에 따라 삭제 또는 삽입을 수행합니다. 이 분기는 명확하게 Optional.isPresent()를 기준으로 나누어 직관적인 로직 흐름을 제공합니다.

응답 일관성 유지
ReviewLikeDto를 통해 좋아요 요청의 최종 상태(좋아요 or 취소됨)를 클라이언트에 명확하게 전달하여 UI의 상태 동기화를 용이하게 했습니다.

close #31 