### PR TITLE
[#41 | 선혜린 | 0530] 리뷰 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,6 +58,14 @@ public class ReviewController {
       @RequestHeader(value = "Deokhugam-Request-User-ID") UUID userId) {
     reviewService.deleteHard(reviewId, userId);
     return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping(path = "/{reviewId}")
+  public ResponseEntity<ReviewDto> findById(
+      @PathVariable UUID reviewId,
+      @RequestHeader(value = "Deokhugam-Request-User-ID") UUID userId) {
+    ReviewDto reviewDto = reviewService.findById(reviewId, userId);
+    return ResponseEntity.ok(reviewDto);
   }
 
   @PostMapping(path = "/{reviewId}/like")

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewLikeRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID> {
 
-  @Query("SELECT COUNT(rl) FROM ReviewLike rl WHERE rl.id = :reviewId")
+  @Query("SELECT COUNT(rl) FROM ReviewLike rl WHERE rl.review.id = :reviewId")
   int countByReviewId(@Param("reviewId") UUID reviewId);
 
   @Query("SELECT CASE WHEN COUNT(rl) > 0 THEN true ELSE false END "

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
@@ -16,6 +16,8 @@ public interface ReviewService {
 
   void deleteHard(UUID id, UUID userId);
 
+  ReviewDto findById(UUID id, UUID userId);
+
   ReviewLikeDto like(UUID id, UUID userId);
 /*
   CursorPageResponseReviewDto findReviews(ReviewSearchCondition condition);

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
@@ -98,6 +98,22 @@ public class BasicReviewService implements ReviewService {
     reviewRepository.delete(review);
   }
 
+  @Override
+  @Transactional
+  public ReviewDto findById(UUID id, UUID userId) {
+    if (!userRepository.existsById(userId)) {
+      throw new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    Review review = reviewRepository.findByIdWithUserAndBook(id)
+        .orElseThrow(() -> new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    int likeCount = reviewLikeRepository.countByReviewId(id);
+    int commentCount = commentRepository.countByReviewIdAndIsDeletedFalse(id);
+    boolean likedByMe = reviewLikeRepository.existsByUserIdAndReviewId(userId, id);
+
+    return ReviewDto.of(review, likeCount, commentCount, likedByMe);
+  }
 
   @Override
   @Transactional

--- a/src/test/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewServiceTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewServiceTest.java
@@ -206,4 +206,35 @@ public class BasicReviewServiceTest {
     verify(reviewLikeRepository, never()).save(any(ReviewLike.class));
     verify(reviewLikeRepository).delete(any());
   }
+
+  @Test
+  @DisplayName("리뷰 상세 조회")
+  void findById_returnsReviewDto() {
+    UUID reviewId = UUID.randomUUID();
+    Review review = Review.create(book, user, "내용입니다.", 5);
+    ReflectionTestUtils.setField(review, "id", reviewId);
+
+    when(userRepository.existsById(userId)).thenReturn(true);
+    when(reviewRepository.findByIdWithUserAndBook(reviewId)).thenReturn(Optional.of(review));
+    when(reviewLikeRepository.countByReviewId(reviewId)).thenReturn(3);
+    when(commentRepository.countByReviewIdAndIsDeletedFalse(reviewId)).thenReturn(2);
+    when(reviewLikeRepository.existsByUserIdAndReviewId(userId, reviewId)).thenReturn(true);
+
+    ReviewDto result = reviewService.findById(reviewId, userId);
+
+    verify(userRepository).existsById(userId);
+    verify(reviewRepository).findByIdWithUserAndBook(reviewId);
+    verify(reviewLikeRepository).countByReviewId(reviewId);
+    verify(commentRepository).countByReviewIdAndIsDeletedFalse(reviewId);
+    verify(reviewLikeRepository).existsByUserIdAndReviewId(userId, reviewId);
+
+    assertThat(result.id()).isEqualTo(reviewId);
+    assertThat(result.userId()).isEqualTo(userId);
+    assertThat(result.bookId()).isEqualTo(bookId);
+    assertThat(result.content()).isEqualTo("내용입니다.");
+    assertThat(result.rating()).isEqualTo(5);
+    assertThat(result.likeCount()).isEqualTo(3);
+    assertThat(result.commentCount()).isEqualTo(2);
+    assertThat(result.likedByMe()).isTrue();
+  }
 }


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?
리뷰 단건 상세 조회 기능을 구현했습니다. 사용자는 특정 리뷰 ID를 통해 리뷰 본문, 작성자 정보, 도서 정보, 좋아요 수, 댓글 수, 본인의 좋아요 여부를 함께 조회할 수 있습니다.

왜 이 작업이 필요한가?
클라이언트에서 개별 리뷰를 클릭해 상세 정보를 확인할 수 있어야 하며, 이를 통해 사용자 경험을 강화하고 상호작용(좋아요, 댓글 등)을 유도할 수 있습니다.
또한, 기존 좋아요 수 집계 쿼리가 잘못된 조건(rl.id = :reviewId)으로 설정되어 있어 정확한 집계가 되지 않았던 문제를 수정하였습니다.

🔍 주요 변경 사항 (What was changed)
ReviewController#like:
- POST /{reviewId}/like 경로에 대한 요청을 처리
- 사용자 ID를 헤더로 받아 reviewService.like() 호출 후, 좋아요 여부 응답

BasicReviewService#findById:
- 리뷰 ID로 리뷰를 조회하고, 관련 도서/작성자 정보까지 fetch
- reviewLikeRepository, commentRepository를 통해 좋아요 수, 댓글 수 집계
- 본인이 해당 리뷰에 좋아요를 눌렀는지 여부까지 포함하여 ReviewDto로 응답

ReviewLikeRepository#countByReviewId:
- 기존 rl.id = :reviewId 조건에서 rl.review.id = :reviewId로 수정하여
특정 리뷰에 대한 총 좋아요 수를 정확히 계산하도록 쿼리 수정

🧩 설계 및 구현 고려사항 (Design decisions)
집계 쿼리의 정확성 확보
기존 countByReviewId()는 ReviewLike 테이블의 id(PK)에 대해 조건을 걸고 있어, 항상 0 또는 부정확한 값이 나왔습니다. 이를 rl.review.id 조건으로 수정하여 특정 리뷰에 연결된 좋아요 수를 올바르게 집계하도록 보완했습니다.

DTO 응답 설계
ReviewDto는 리뷰 본문뿐 아니라 도서 제목/썸네일, 작성자 닉네임, 좋아요 수, 댓글 수, 본인 좋아요 여부까지 포함하고 있어 클라이언트 UI 구성을 위한 충분한 정보를 제공합니다.

사용자 인증 및 존재 검증
리뷰 상세 조회 시 유저 ID의 존재 여부를 먼저 검증하여, 비정상 요청이나 탈퇴 유저의 접근에 대한 예외 처리를 명확하게 했습니다.

Repository 의존성 최소화
각 집계 정보는 단일 쿼리로 처리되며, 서비스 내 로직이 명확히 분리되어 있어 유지보수 및 테스트 용이성을 높였습니다.

close #41 