### PR TITLE
Feat delete notification

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/config/SchedulerConfig.java
+++ b/src/main/java/com/sprint/deokhugamteam7/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.sprint.deokhugamteam7.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package com.sprint.deokhugamteam7.domain.notification.repository;
 
 import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,4 +21,8 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   @Modifying
   @Query("UPDATE Notification n SET n.confirmed = true WHERE n.review.user.id = :user_id")
   void bulkUpdateConfirmed(UUID user_id);
+
+  @Modifying
+  @Query("UPDATE Notification n SET n.isDelete = true  WHERE n.isDelete = false AND n.created_at < :threshold")
+  void softDeleteOldNotifications(LocalDateTime threshold);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
@@ -9,10 +9,12 @@ import com.sprint.deokhugamteam7.domain.notification.service.NotificationService
 import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
 import com.sprint.deokhugamteam7.exception.ErrorCode;
 import com.sprint.deokhugamteam7.exception.notification.NotificationException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +54,11 @@ public class NotificationServiceImpl implements NotificationService {
   public CursorPageResponseNotificationDto findAll(UUID userId) {
     notificationRepository.findAllByReviewerId(userId);
     return null;
+  }
+
+  @Scheduled(cron = "0 0 0 * * Sun")
+  public void softDeleteNotificationsOlderThanAWeek() {
+    notificationRepository.softDeleteOldNotifications(LocalDateTime.now().minusWeeks(1));
   }
 
 }

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepositoryTest.java
@@ -9,6 +9,7 @@ import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,5 +78,14 @@ class NotificationRepositoryTest {
 
         List<Notification> afterUpdate = notificationRepository.findAllByReviewerId(reviewer.getId());
         assertThat(afterUpdate).allMatch(Notification::getConfirmed);
+    }
+
+    @Test
+    void softDeleteNotificationsOlderThanNow() {
+        assertThat(notificationRepository.findAllByReviewerId(reviewer.getId())).hasSize(3);
+
+        notificationRepository.softDeleteOldNotifications(LocalDateTime.now());
+
+        assertThat(notificationRepository.findAllByReviewerId(reviewer.getId())).isEmpty();
     }
 }


### PR DESCRIPTION
## 🚀 PR 제목

주기적 알림 정리 기능 추가 (스케줄러 기반 Soft Delete 적용)

---

## 📌 개요 (What & Why)

- **무엇을 구현했는가?**  
  생성된 지 일주일이 지난 알림(Notification) 데이터를 매주 일요일 0시에 소프트 삭제하는 기능을 추가했습니다. 알림은 즉시 삭제되지 않고 `isDelete` 플래그를 `true`로 업데이트하는 방식으로 처리됩니다.

- **왜 이 작업이 필요한가?**  
  알림 데이터는 시간이 지남에 따라 누적되어 저장소를 차지하게 됩니다. 사용자 입장에서는 오래된 알림을 계속 노출할 필요가 없고, 시스템 입장에서도 불필요한 데이터가 쌓이면 성능 및 유지관리 측면에서 부담이 됩니다. 따라서 주기적으로 알림을 정리함으로써 성능을 개선하고, 클린한 데이터 관리를 도모하고자 이 기능을 도입했습니다.

---

## 🔍 주요 변경 사항 (What was changed)

- `SchedulerConfig`:  
  - `@EnableScheduling` 어노테이션을 통해 Spring Scheduling 기능을 전역 활성화했습니다.

- `NotificationServiceImpl`:  
  - `@Scheduled(cron = "0 0 0 * * Sun")`을 사용해 매주 일요일 자정마다 동작하는 스케줄러 메서드를 추가했습니다.
  - 메서드 내부에서는 생성일이 1주일 이상 지난 알림을 soft delete 처리하도록 repository 메서드를 호출합니다.

- `NotificationRepository`:  
  - `@Modifying @Query` 기반으로 `isDelete = false`이고 생성일이 기준(threshold) 이전인 알림을 대상으로 soft delete 수행하는 쿼리 메서드 `softDeleteOldNotifications()` 추가.

- `NotificationRepositoryTest`:  
  - soft delete 쿼리의 동작 여부를 검증하는 단위 테스트 작성. 기준 시간 이전 알림이 삭제되었는지 확인합니다.

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **소프트 삭제 방식 선택 이유**  
  실제 데이터를 삭제하지 않고 `isDelete` 필드로 관리하는 soft delete 전략을 사용했습니다. 이 접근은 복구 가능성을 열어두며, 추후 통계나 로깅, 감사 로그 용도로 데이터를 활용할 수 있도록 합니다. 또한 JPA 레벨에서 필터링 쿼리를 통해 삭제된 데이터를 쉽게 제외할 수 있어, 유연하고 안전한 방식입니다.

- **스케줄러 실행 주기**  
  사용자 알림 특성상 매일 정리보다는 주간 단위 정리가 적절하다고 판단하여 cron 표현식을 통해 주 1회(일요일 0시) 자동 정리되도록 설정했습니다. 이는 시스템 자원 사용을 최소화하면서도 알림 데이터 정리에 충분한 주기를 제공합니다.

- **Repository 테스트 구성**  
  실제 soft delete가 수행되는 조건을 명확히 테스트하기 위해, 테스트에서는 기준 시간 이전 알림이 모두 `isDelete = true`로 변경되는지를 확인하는 검증을 포함시켰습니다. 이는 쿼리 조건이 정확하게 동작하는지를 보장하기 위한 목적입니다.
