### PR TITLE
[한성태 | 06-02] 알림 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/contoller/NotificationController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/contoller/NotificationController.java
@@ -1,5 +1,7 @@
 package com.sprint.deokhugamteam7.domain.notification.contoller;
 
+import com.sprint.deokhugamteam7.domain.notification.dto.CursorPageResponseNotificationDto;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationCursorRequest;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
 import com.sprint.deokhugamteam7.domain.notification.service.NotificationService;
@@ -7,6 +9,9 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -37,5 +42,13 @@ public class NotificationController {
     ) {
         notificationService.updateAll(userId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("")
+    public ResponseEntity<CursorPageResponseNotificationDto> findAll(
+        @Validated @ModelAttribute NotificationCursorRequest request
+    ) {
+        CursorPageResponseNotificationDto result = notificationService.findAll(request);
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/dto/CursorPageResponseNotificationDto.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/dto/CursorPageResponseNotificationDto.java
@@ -1,6 +1,7 @@
 package com.sprint.deokhugamteam7.domain.notification.dto;
 
 import java.util.List;
+import org.springframework.data.domain.Slice;
 
 public record CursorPageResponseNotificationDto(
     List<NotificationDto> content,
@@ -10,5 +11,26 @@ public record CursorPageResponseNotificationDto(
     long totalElements,
     boolean hasNext
 ) {
+    public static CursorPageResponseNotificationDto fromSlice(
+        Slice<NotificationDto> slice,
+        long totalElements
+    ) {
+        String nextCursor = null;
+        String nextAfter = null;
+        if (slice.hasNext() && !slice.getContent().isEmpty()) {
+            NotificationDto last = slice.getContent().get(slice.getContent().size() - 1);
+            nextCursor = last.createdAt().toString();
+            nextAfter = last.createdAt().toString();
+        }
+
+        return new CursorPageResponseNotificationDto(
+            slice.getContent(),
+            nextCursor,
+            nextAfter,
+            slice.getPageable().getPageSize(),
+            totalElements,
+            slice.hasNext()
+        );
+    }
 
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/dto/NotificationCursorRequest.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/dto/NotificationCursorRequest.java
@@ -1,0 +1,31 @@
+package com.sprint.deokhugamteam7.domain.notification.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+public record NotificationCursorRequest(
+    @NotNull
+    UUID userId,
+    @DefaultValue(value = "DESC")
+    String direction,
+    String cursor,
+    LocalDateTime after,
+    @DefaultValue(value = "20")
+    Integer limit
+) {
+    @AssertTrue(message = "cursor가 존재하면 after(보조 커서)도 반드시 존재해야 합니다.")
+    public boolean isCursorAfterValid() {
+        if (cursor != null && !cursor.isBlank()) {
+            return after != null;
+        }
+        return true;
+    }
+
+    public LocalDateTime parsedCursor() {
+        if (cursor == null || cursor.isBlank()) return null;
+        return LocalDateTime.parse(cursor);
+    }
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepository.java
@@ -1,22 +1,19 @@
 package com.sprint.deokhugamteam7.domain.notification.repository;
 
 import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
+import com.sprint.deokhugamteam7.domain.notification.repository.custom.NotificationRepositoryCustom;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+public interface NotificationRepository extends JpaRepository<Notification, UUID>,
+    NotificationRepositoryCustom {
 
-  @Query("SELECT n FROM Notification n "
-      + "JOIN FETCH n.user u "
-      + "JOIN FETCH n.review r "
-      + "WHERE n.review.user.id = :user_id AND n.isDelete = false ")
-  List<Notification> findAllByReviewerId(UUID user_id);
+  @Query("SELECT n FROM Notification n WHERE n.user.id = :userId AND n.isDelete = false ")
+  List<Notification> findByUserId(UUID userId);
 
   @Modifying
   @Query("UPDATE Notification n SET n.confirmed = true WHERE n.review.user.id = :user_id")

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/custom/NotificationRepositoryCustom.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/custom/NotificationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.sprint.deokhugamteam7.domain.notification.repository.custom;
+
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationCursorRequest;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
+import java.util.UUID;
+import org.springframework.data.domain.Slice;
+
+public interface NotificationRepositoryCustom {
+    Slice<NotificationDto> findAllByCursor(NotificationCursorRequest request);
+    long countAllById(UUID userId);
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/impl/NotificationRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/impl/NotificationRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.sprint.deokhugamteam7.domain.notification.repository.impl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationCursorRequest;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
+import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
+import com.sprint.deokhugamteam7.domain.notification.entity.QNotification;
+import com.sprint.deokhugamteam7.domain.notification.repository.custom.NotificationRepositoryCustom;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QNotification notification = QNotification.notification;
+
+    @Override
+    public Slice<NotificationDto> findAllByCursor(NotificationCursorRequest request) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // where
+        builder.and(notification.user.id.eq(request.userId()));
+        builder.and(notification.isDelete.eq(false));
+
+        if (request.cursor() != null && !request.cursor().isEmpty() && request.after() != null) {
+            LocalDateTime cursor = request.parsedCursor();
+
+            if ("ASC".equalsIgnoreCase(request.direction())) {
+                builder.and(notification.created_at.gt(cursor));
+            } else {
+                builder.and(notification.created_at.lt(cursor));
+            }
+        }
+
+        // orderBy
+        OrderSpecifier<?>[] orderSpecifiers = "ASC".equalsIgnoreCase(request.direction())
+            ? new OrderSpecifier[]{notification.created_at.asc()}
+            : new OrderSpecifier[]{notification.created_at.desc()};
+
+        List<Notification> notificationList = queryFactory
+            .selectFrom(notification)
+            .where(builder)
+            .orderBy(orderSpecifiers)
+            .limit(request.limit() + 1)
+            .fetch();
+
+        boolean hasNext = notificationList.size() > request.limit();
+        List<Notification> content = hasNext ? notificationList.subList(0, request.limit()) : notificationList;
+
+        List<NotificationDto> notificationDtoList = content.stream()
+            .map(NotificationDto::fromEntity)
+            .toList();
+
+        return new SliceImpl<>(notificationDtoList, PageRequest.of(0, request.limit()), hasNext);
+    }
+
+    @Override
+    public long countAllById(UUID userId) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(notification.user.id.eq(userId));
+        builder.and(notification.isDelete.eq(false));
+
+        return queryFactory.selectFrom(notification)
+            .where(builder)
+            .stream().count();
+    }
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.sprint.deokhugamteam7.domain.notification.service;
 
 import com.sprint.deokhugamteam7.domain.notification.dto.CursorPageResponseNotificationDto;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationCursorRequest;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
 import java.util.List;
@@ -12,5 +13,5 @@ public interface NotificationService {
 
   void updateAll(UUID userId);
 
-  CursorPageResponseNotificationDto findAll(UUID userId);
+  CursorPageResponseNotificationDto findAll(NotificationCursorRequest request);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
@@ -1,6 +1,7 @@
 package com.sprint.deokhugamteam7.domain.notification.service.impl;
 
 import com.sprint.deokhugamteam7.domain.notification.dto.CursorPageResponseNotificationDto;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationCursorRequest;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
 import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,9 +53,17 @@ public class NotificationServiceImpl implements NotificationService {
 
   @Override
   @Transactional(readOnly = true)
-  public CursorPageResponseNotificationDto findAll(UUID userId) {
-    notificationRepository.findAllByReviewerId(userId);
-    return null;
+  public CursorPageResponseNotificationDto findAll(NotificationCursorRequest request) {
+    userRepository.findById(request.userId())
+        .orElseThrow(() -> new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+    Slice<NotificationDto> sliceNotificationDto = notificationRepository.findAllByCursor(request);
+    long totalElements = notificationRepository.countAllById(request.userId());
+
+    return CursorPageResponseNotificationDto.fromSlice(
+        sliceNotificationDto,
+        totalElements
+    );
   }
 
   @Scheduled(cron = "0 0 0 * * Sun")

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/config/TestConfig.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/config/TestConfig.java
@@ -1,0 +1,22 @@
+package com.sprint.deokhugamteam7.domain.notification.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@TestConfiguration
+public class TestConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+
+}


### PR DESCRIPTION
## 🚀 PR 제목

알림 목록 커서 기반 페이지네이션 조회 기능 구현

---

## 📌 개요 (What & Why)

- **무엇을 구현했는가?**  
  사용자가 자신의 알림 목록을 효율적으로 조회할 수 있도록, 커서 기반 페이지네이션 방식의 조회 기능을 구현했습니다. 단순한 offset 방식이 아닌 커서를 이용한 방식으로, 성능 최적화 및 안정적인 페이징 처리를 가능하게 합니다.

- **왜 이 작업이 필요한가?**  
  기존의 페이징 방식은 데이터가 많아질수록 조회 성능이 저하되며, 페이지 중간에 데이터 변경이 발생하면 사용자 경험이 불안정해지는 문제가 있습니다. 특히 알림처럼 지속적으로 생성되고 삭제되는 데이터의 경우 커서 기반이 더 적합합니다. 이 변경은 알림 목록 API의 신뢰성과 확장성을 높이기 위한 개선 작업입니다.

---

## 🔍 주요 변경 사항 (What was changed)

- `NotificationRepositoryImpl`
  - `findAllByCursor(NotificationCursorRequest)` 메서드 구현  
    → QueryDSL 기반의 동적 쿼리를 활용하여, 사용자 ID, 삭제 여부, 커서 방향에 따라 조건을 구성  
    → 정렬 방향에 따라 `created_at` 기준으로 페이징 처리  
    → `limit + 1` 데이터를 조회해 `hasNext` 여부 판단, `Slice` 반환

  - `countAllById(UUID userId)` 메서드 추가  
    → 전체 알림 개수를 계산하여 페이지네이션 응답에 활용

- `NotificationCursorRequest`
  - 사용자 ID, 정렬 방향, 커서 시간, 보조 커서, 페이지 크기 등의 요청 파라미터 정의
  - `@AssertTrue` 사용하여 커서가 존재하면 보조 커서도 반드시 존재하도록 검증 로직 추가

- `CursorPageResponseNotificationDto`
  - 커서 기반 Slice 응답 DTO 정의
  - 다음 커서 및 페이지 크기, 전체 개수, 다음 페이지 존재 여부 포함

- `NotificationServiceImpl`
  - `findAll(NotificationCursorRequest)` 메서드 구현  
    → 사용자 존재 검증 후, Repository에서 Slice 및 전체 개수 조회  
    → 응답 DTO로 변환 후 반환

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **커서 기반 페이지네이션 설계 이유**  
  `OFFSET` 기반 페이지네이션은 대량의 알림 데이터를 처리할 때 성능 저하 및 데이터 무결성 문제를 유발할 수 있습니다. 커서 기반은 불변의 커서를 기준으로 데이터를 조회하여 성능과 정합성을 동시에 확보할 수 있습니다.

- **QueryDSL 사용 이유**  
  복잡한 조건 쿼리를 명확하고 타입 안전하게 작성할 수 있으며, 유지보수성과 테스트 용이성을 높이기 위해 QueryDSL을 도입했습니다.

- **Slice 사용 이유**  
  커서 기반 방식은 전체 페이지 수 계산이 필요 없으므로 `Page` 대신 `Slice`를 사용했습니다. `limit + 1` 방식으로 `hasNext` 여부만 판단하면 되므로 성능상 유리합니다.

- **DTO 분리 설계**  
  요청과 응답을 각각 DTO로 명확하게 분리하여, 레이어 간 의존도를 낮추고 API 유연성을 확보했습니다.

