### PR TITLE
[#44 | 선혜린 | 0602] 리뷰 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
@@ -1,7 +1,9 @@
 package com.sprint.deokhugamteam7.domain.review.controller;
 
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.response.CursorPageResponseReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewLikeDto;
 import com.sprint.deokhugamteam7.domain.review.service.ReviewService;
@@ -76,5 +78,13 @@ public class ReviewController {
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(reviewLikeDto);
+  }
+
+  @GetMapping
+  public ResponseEntity<CursorPageResponseReviewDto> findAll(
+      ReviewSearchCondition condition,
+      @RequestHeader(value = "Deokhugam-Request-User-ID") UUID headerUserId) {
+    CursorPageResponseReviewDto reviewDto = reviewService.findAll(condition, headerUserId);
+    return ResponseEntity.ok(reviewDto);
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/request/ReviewSearchCondition.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/request/ReviewSearchCondition.java
@@ -1,17 +1,21 @@
 package com.sprint.deokhugamteam7.domain.review.dto.request;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Getter;
+import lombok.Setter;
 
-public record ReviewSearchCondition(
-    UUID userId,
-    UUID bookId,
-    String keyword,
-    String orderBy,
-    String direction,
-    String cursor,
-    Instant after,
-    int limit
-) {
+@Getter
+@Setter
+public class ReviewSearchCondition {
 
+  private UUID userId;
+  private UUID bookId;
+  private String keyword;
+  private String orderBy = "createdAt";
+  private String direction = "DESC";
+  private String cursor;
+  private LocalDateTime after;
+  private int limit = 50;
+  private UUID requestUserId;
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/Review.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/Review.java
@@ -63,7 +63,6 @@ public class Review {
   @Column(updatable = false)
   private LocalDateTime updatedAt;
 
-  // 두 List가 필요없다는게 확인 됨. 그래도 혹시 모르니, 기능 구현이 끝나기 전까진 놔둘 예정.
   @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Comment> commentList;
 

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.sprint.deokhugamteam7.domain.review.repository;
+
+import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import java.util.List;
+
+public interface ReviewRepositoryCustom {
+
+  List<Review> findAll(ReviewSearchCondition condition, int limit);
+
+  long countByCondition(ReviewSearchCondition condition);
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,0 +1,108 @@
+package com.sprint.deokhugamteam7.domain.review.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.deokhugamteam7.domain.book.entity.QBook;
+import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
+import com.sprint.deokhugamteam7.domain.review.entity.QReview;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.user.entity.QUser;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Override
+  public List<Review> findAll(ReviewSearchCondition condition, int limit) {
+    QReview review = QReview.review;
+    QUser user = QUser.user;
+    QBook book = QBook.book;
+
+    JPAQuery<Review> query = new JPAQueryFactory(em)
+        .selectFrom(review)
+        .join(review.user, user).fetchJoin()
+        .join(review.book, book).fetchJoin();
+
+    BooleanBuilder where = new BooleanBuilder();
+
+    if (condition.getUserId() != null) {
+      where.and(review.user.id.eq(condition.getUserId()));
+    }
+    if (condition.getBookId() != null) {
+      where.and(review.book.id.eq(condition.getBookId()));
+    }
+    if (condition.getKeyword() != null) {
+      String keyword = "%" + condition.getKeyword().toLowerCase() + "%";
+      where.and(
+          review.content.lower().like(keyword)
+              .or(user.nickname.lower().like(keyword))
+              .or(book.title.lower().like(keyword))
+              .or(book.description.lower().like(keyword))
+      );
+    }
+
+    String orderby = condition.getOrderBy();
+    String cursor = condition.getCursor();
+    LocalDateTime after = condition.getAfter();
+
+    if ("rating".equals(orderby)) {
+      if (cursor != null && after != null) {
+        int ratingCursor = (int) Double.parseDouble(cursor);
+        where.and(
+            review.rating.lt(ratingCursor)
+                .or(review.rating.eq(ratingCursor))
+                .and(review.createdAt.lt(after))
+        );
+      }
+      query.orderBy(review.rating.desc(), review.createdAt.desc());
+    } else {
+      if (after != null) {
+        where.and(review.createdAt.lt(after));
+      }
+      query.orderBy(review.createdAt.desc());
+    }
+
+    query.where(where)
+        .limit(limit + 1);
+
+    return query.fetch();
+  }
+
+  public long countByCondition(ReviewSearchCondition condition) {
+    QReview review = QReview.review;
+
+    BooleanBuilder where = new BooleanBuilder();
+
+    if (condition.getUserId() != null) {
+      where.and(review.user.id.eq(condition.getUserId()));
+    }
+    if (condition.getBookId() != null) {
+      where.and(review.book.id.eq(condition.getBookId()));
+    }
+    if (condition.getKeyword() != null) {
+      String keyword = "%" + condition.getKeyword().toLowerCase() + "%";
+      where.and(
+          review.content.lower().like(keyword)
+              .or(review.user.nickname.lower().like(keyword))
+              .or(review.book.title.lower().like(keyword))
+              .or(review.book.description.lower().like(keyword))
+      );
+    }
+
+    Long res = new JPAQueryFactory(em)
+        .select(review.count())
+        .from(review)
+        .where(where)
+        .fetchOne();
+
+    return res != null ? res : 0;
+  }
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
@@ -1,7 +1,9 @@
 package com.sprint.deokhugamteam7.domain.review.service;
 
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.response.CursorPageResponseReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewLikeDto;
 import java.util.UUID;
@@ -19,8 +21,6 @@ public interface ReviewService {
   ReviewDto findById(UUID id, UUID userId);
 
   ReviewLikeDto like(UUID id, UUID userId);
-/*
-  CursorPageResponseReviewDto findReviews(ReviewSearchCondition condition);
-*/
 
+  CursorPageResponseReviewDto findAll(ReviewSearchCondition condition, UUID headerUserId);
 }


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?
리뷰 목록 조회 시 커서 기반 페이지네이션 및 다양한 필터 조건(작성자, 도서, 키워드)을 적용할 수 있도록 기능을 구현했습니다.
추가로, 이 기능의 정상 동작을 보장하기 위한 단위 테스트를 BasicReviewServiceTest에 작성하였습니다.

왜 이 작업이 필요한가?
커서 기반 페이지네이션은 무한 스크롤 구조에 적합하고 성능상 효율적입니다. 다양한 정렬 및 필터링 옵션을 제공함으로써 사용자는 원하는 리뷰를 보다 쉽게 탐색할 수 있으며, 클라이언트는 hasNext, nextCursor, totalElements를 활용하여 자연스러운 UX 흐름을 구현할 수 있습니다.
테스트 코드는 이러한 복합 로직의 정확성과 회귀 방지를 보장하기 위해 필수입니다.

🔍 주요 변경 사항 (What was changed)
ReviewController#findAll:
- GET /reviews 경로에서 ReviewSearchCondition 기반으로 목록 요청 처리
- 사용자 ID를 헤더로 전달받아 서비스로 위임

BasicReviewService#findAll:
- QueryDSL 기반 커서 페이지네이션 구현
- 요청 조건에 따라 리뷰 목록 조회 및 다음 커서 계산
- 각 리뷰에 대해 좋아요 수, 댓글 수, 본인 좋아요 여부까지 포함한 ReviewDto 리스트 생성
- 전체 리뷰 수 집계 후 CursorPageResponseReviewDto로 응답

ReviewRepositoryImpl:
- findAll(): 사용자 ID, 도서 ID, 키워드, 정렬 기준(createdAt, rating)에 따른 커서 처리 및 리뷰 목록 조회
- countByCondition(): 동일 조건에 대한 총 리뷰 개수 계산

BasicReviewServiceTest#findAll_returnsCursorPageResponseReviewDto:
- 커서 페이지네이션에서 3개 중 2개만 반환되며 hasNext = true임을 검증
- 각 리뷰에 대한 좋아요 수, 댓글 수, 좋아요 여부가 DTO에 정확히 반영되는지 검증
- nextCursor, nextAfter 값이 마지막 항목 기준으로 정확히 계산되는지 확인

🧩 설계 및 구현 고려사항 (Design decisions)
커서 기반 페이지네이션 구조
limit + 1 방식으로 다음 페이지 존재 여부 판단 후, 실제 응답에는 최대 limit만 포함.
nextAfter, nextCursor는 정렬 기준에 따라 동적으로 구성 (createdAt 또는 rating 기준 분기 처리).

리뷰 필터 조건 설계
검색어는 Review.content, User.nickname, Book.title, Book.description에 대해 lower-case LIKE 조건으로 처리하여 범용성 높은 검색 기능 제공.

테스트 케이스 보강
다양한 작성자와 생성일을 가진 더미 리뷰 3개를 통해 limit=2 조건에서 페이지네이션이 의도대로 작동하는지 확인.
Mockito.verify()를 통해 각 저장소가 올바르게 호출되었는지도 검증하여, 내부 동작 흐름의 정확성까지 체크.

응답 일관성 보장
모든 리뷰 항목은 ReviewDto로 통일된 형태로 변환되며, 클라이언트는 어떤 조건이든 일관된 구조로 데이터를 받을 수 있도록 설계.

