### PR TITLE
[한성태 | 0602] 알람 생성 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/constant/NotificationType.java
+++ b/src/main/java/com/sprint/deokhugamteam7/constant/NotificationType.java
@@ -1,0 +1,22 @@
+package com.sprint.deokhugamteam7.constant;
+
+import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+
+public enum NotificationType {
+    LIKE("[%s]님이 나의 리뷰를 좋아합니다."),
+    COMMENT("[%s]님이 나의 리뷰에 댓글을 남겼습니다.\n%s");
+
+    private final String message;
+
+    NotificationType(String message) {
+        this.message = message;
+    }
+
+    public String formatMessage(User user, Comment comment) {
+        return switch (this) {
+            case LIKE -> String.format(message, user.getNickname());
+            case COMMENT -> String.format(message, user.getNickname(), comment.getContent());
+        };
+    }
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/comment/service/CommentService.java
@@ -1,11 +1,14 @@
 package com.sprint.deokhugamteam7.domain.comment.service;
 
+import com.sprint.deokhugamteam7.constant.NotificationType;
 import com.sprint.deokhugamteam7.domain.comment.dto.CommentDto;
 import com.sprint.deokhugamteam7.domain.comment.dto.request.CommentCreateRequest;
 import com.sprint.deokhugamteam7.domain.comment.dto.request.CommentUpdateRequest;
 import com.sprint.deokhugamteam7.domain.comment.dto.response.CursorPageResponseCommentDto;
 import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
 import com.sprint.deokhugamteam7.domain.comment.repository.CommentRepository;
+import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
+import com.sprint.deokhugamteam7.domain.notification.repository.NotificationRepository;
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import com.sprint.deokhugamteam7.domain.review.repository.ReviewRepository;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
@@ -27,6 +30,7 @@ public class CommentService {
 	private final CommentRepository commentRepository;
 	private final UserRepository userRepository;
 	private final ReviewRepository reviewRepository;
+	private final NotificationRepository notificationRepository;
 
 	@Transactional
 	public CommentDto create(CommentCreateRequest commentCreateRequest) {
@@ -52,6 +56,8 @@ public class CommentService {
 		Comment newComment = Comment.create(user, review, content);
 		Comment savedComment = commentRepository.save(newComment);
 		// 댓글 생성 시 리뷰의 댓글 수를 증가 + 알림 생성 해야함.
+		Notification notification = Notification.create(review.getUser(), review, NotificationType.COMMENT.formatMessage(user, newComment));
+		notificationRepository.save(notification);
 
 		return CommentDto.from(savedComment);
 	}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/dto/NotificationCursorRequest.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/dto/NotificationCursorRequest.java
@@ -4,18 +4,24 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import org.springframework.boot.context.properties.bind.DefaultValue;
 
 public record NotificationCursorRequest(
     @NotNull
     UUID userId,
-    @DefaultValue(value = "DESC")
     String direction,
     String cursor,
     LocalDateTime after,
-    @DefaultValue(value = "20")
     Integer limit
 ) {
+    public NotificationCursorRequest {
+        if (direction == null || direction.isBlank()) {
+            direction = "DESC";
+        }
+        if (limit == null) {
+            limit = 20;
+        }
+    }
+
     @AssertTrue(message = "cursor가 존재하면 after(보조 커서)도 반드시 존재해야 합니다.")
     public boolean isCursorAfterValid() {
         if (cursor != null && !cursor.isBlank()) {

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
@@ -1,9 +1,12 @@
 package com.sprint.deokhugamteam7.domain.review.service.basic;
 
+import com.sprint.deokhugamteam7.constant.NotificationType;
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.book.entity.RankingBook;
 import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
 import com.sprint.deokhugamteam7.domain.comment.repository.CommentRepository;
+import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
+import com.sprint.deokhugamteam7.domain.notification.repository.NotificationRepository;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
@@ -38,6 +41,7 @@ public class BasicReviewService implements ReviewService {
   private final ReviewLikeRepository reviewLikeRepository;
   private final CommentRepository commentRepository;
   private final ReviewRepositoryCustom reviewRepositoryCustom;
+  private final NotificationRepository notificationRepository;
 
   @Override
   @Transactional
@@ -157,6 +161,9 @@ public class BasicReviewService implements ReviewService {
 
       ReviewLike reviewLike = ReviewLike.create(user, review);
       reviewLikeRepository.save(reviewLike);
+
+      Notification notification = Notification.create(review.getUser(), review, NotificationType.LIKE.formatMessage(user, null));
+      notificationRepository.save(notification);
     }
 
     return new ReviewLikeDto(id, userId, liked);

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/entity/NotificationTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/entity/NotificationTest.java
@@ -1,12 +1,17 @@
 package com.sprint.deokhugamteam7.domain.notification.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.sprint.deokhugamteam7.constant.NotificationType;
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
 import com.sprint.deokhugamteam7.exception.ErrorCode;
 import com.sprint.deokhugamteam7.exception.notification.NotificationException;
+import java.time.LocalDate;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,11 +36,33 @@ class NotificationTest {
         otherUser = User.create("test2", "test2", "test2");
         setPrivateField(otherUser, "id", OTHER_USER_ID);
 
-        review = new Review();
+        Book book = Book.create("testBook", "testBook", "testBook", LocalDate.now()).build();
+
+        review = Review.create(book, user, "책의 리뷰입니다.", 3);
         setPrivateField(review, "user", user);
 
         notification = Notification.create(user, review, "테스트 알림");
         setPrivateField(notification, "id", NOTIFICATION_ID);
+    }
+
+    @Test
+    @DisplayName("알림 생성 성공 - Like")
+    void createNotificationWithNotificationTypeToLike() {
+        Notification likeNotification = Notification.create(user, review, NotificationType.LIKE.formatMessage(otherUser, null));
+
+        assertThat(likeNotification.getContent()).isEqualTo("[test2]님이 나의 리뷰를 좋아합니다.");
+        assertThat(likeNotification.isDelete()).isFalse();
+    }
+
+    @Test
+    @DisplayName("알림 생성 성공 - Like")
+    void createNotificationWithNotificationTypeToComment() {
+        Comment comment = Comment.create(otherUser, review, "댓글 테스트"); // 에러 발생 부분
+
+        Notification likeNotification = Notification.create(user, review, NotificationType.COMMENT.formatMessage(otherUser, comment));
+
+        assertThat(likeNotification.getContent()).isEqualTo("[test2]님이 나의 리뷰에 댓글을 남겼습니다.\n댓글 테스트");
+        assertThat(likeNotification.isDelete()).isFalse();
     }
 
     @Test

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImplTest.java
@@ -5,12 +5,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
 import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
 import com.sprint.deokhugamteam7.domain.notification.repository.NotificationRepository;
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +49,9 @@ class NotificationServiceImplTest {
         otherUser = User.create("test2", "test2", "test2");
         setPrivateField(otherUser, "id", OTHER_USER_ID);
 
-        review = new Review();
+        Book book = Book.create("testBook", "testBook", "testBook", LocalDate.now()).build();
+
+        review = Review.create(book, user, "책의 리뷰입니다.", 3);
         setPrivateField(review, "user", user);
 
         notification = Notification.create(user, review, "테스트 알림");


### PR DESCRIPTION
## 🚀 PR 제목  
알림 메시지 생성을 위한 `NotificationType` Enum 도입 및 메시지 포맷 일원화

---

## 📌 개요 (What & Why)

- **무엇을 구현했는가?**  
  사용자의 리뷰에 대한 "좋아요" 또는 "댓글" 작성 시, 알림 메시지를 생성하는 로직을 `NotificationType` enum을 통해 일관된 방식으로 추상화했습니다. 각 알림 유형에 대해 메시지 템플릿을 정의하고, 사용자 및 댓글 정보를 기반으로 메시지를 포맷하여 알림 객체를 생성합니다.

- **왜 이 작업이 필요한가?**  
  기존에는 알림 메시지를 개별적으로 구성하거나 하드코딩하는 방식으로 처리할 여지가 있어, 코드 중복과 유지보수 어려움이 있었습니다. 알림 타입에 따른 메시지 생성 방식을 하나의 책임으로 위임함으로써 **응집력 있는 설계**와 **가독성 향상**, 그리고 **기능 확장에 용이한 구조**를 마련하기 위해 해당 Enum을 도입했습니다.

---

## 🔍 주요 변경 사항 (What was changed)

- `NotificationType` enum 생성  
  - 각 알림 유형(LIKE, COMMENT)에 대한 메시지 템플릿 정의  
  - `formatMessage(User user, Comment comment)` 메서드를 통해 알림 대상 사용자 및 댓글 내용을 바탕으로 동적으로 메시지를 생성하도록 구현

- `Notification` 생성 시 `NotificationType` 활용  
  - `NotificationType.LIKE.formatMessage(user, null)`를 통해 "좋아요" 알림 메시지 생성  
  - `NotificationType.COMMENT.formatMessage(user, newComment)`를 통해 댓글 알림 메시지 생성

- 알림 저장 시점에서 메시지 포맷이 이미 완료되어 있어, 별도 메시지 가공 로직이 필요 없음

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **Enum 기반 메시지 포맷 일원화**  
  알림 타입마다 메시지를 다르게 구성해야 하는 요구사항이 명확해졌고, 추후 새로운 알림 유형(예: 친구 요청, 신고 처리 등)이 추가될 수 있음을 고려하여 `enum`을 통해 메시지 템플릿을 타입별로 모듈화했습니다. 이는 OCP 원칙(확장에는 열려있고 변경에는 닫혀있는 구조)을 따른 설계입니다.

- **가독성과 유지보수성 향상**  
  메시지 생성 로직이 controller/service 단에 흩어져 있을 경우, 타입별 메시지를 변경하거나 검토할 때 일관성 유지가 어렵습니다. `NotificationType`에 메시지 관련 책임을 집중시킴으로써, 알림 메시지 수정이 한 곳에서 가능하며 코드 흐름을 명확하게 파악할 수 있습니다.

- **Null 안전 고려**  
  `LIKE` 알림에서는 댓글 정보가 필요 없으므로, `formatMessage` 메서드에서 `comment` 인자가 `null`인 경우에도 안전하게 처리되도록 분기 로직을 설계했습니다. 각 알림 타입의 책임이 명확히 분리되어 있어, 입력값의 조건에 따른 의도치 않은 예외를 예방할 수 있습니다.
