### PR TITLE
[한성태 | 0603] GlobalExceptionAdvice 예외 처리 응답 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/exception/DeokhugamException.java
+++ b/src/main/java/com/sprint/deokhugamteam7/exception/DeokhugamException.java
@@ -1,17 +1,28 @@
 package com.sprint.deokhugamteam7.exception;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 
 @Getter
 public class DeokhugamException extends RuntimeException {
 
-  private final LocalDate timestamp;
+  private final LocalDateTime timestamp;
   private final ErrorCode errorCode;
+  private final Map<String, String> details;
 
   public DeokhugamException(ErrorCode errorCode) {
     super(errorCode.getMessage());
-    this.timestamp = LocalDate.now();
+    this.timestamp = LocalDateTime.now();
     this.errorCode = errorCode;
+    this.details = Map.of();
+  }
+
+  public DeokhugamException(ErrorCode errorCode, Map<String, String> details) {
+    super(errorCode.getMessage());
+    this.timestamp = LocalDateTime.now();
+    this.errorCode = errorCode;
+    this.details = details;
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/deokhugamteam7/exception/ErrorCode.java
@@ -2,13 +2,16 @@ package com.sprint.deokhugamteam7.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-  INTERNAL_SERVER_ERROR(500, "S001", "Internal Server Error");
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "Internal Server Error"),
+  NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "?", "알림을 찾을 수 없습니다."),
+  NOTIFICATION_NOT_OWNED(HttpStatus.FORBIDDEN, "?", "본인의 알람만 조회/수정할 수 있습니다.");
 
-  private final int httpStatus;
+  private final HttpStatus httpStatus;
   private final String code;
   private final String message;
 }

--- a/src/main/java/com/sprint/deokhugamteam7/exception/ErrorResponse.java
+++ b/src/main/java/com/sprint/deokhugamteam7/exception/ErrorResponse.java
@@ -1,9 +1,24 @@
 package com.sprint.deokhugamteam7.exception;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Map;
 
 public record ErrorResponse(
-    Instant timestamp, int status, String code, String message, String exceptionType
+    LocalDateTime timestamp,
+    String code,
+    String message,
+    Map<String, String> details,
+    String exceptionType,
+    int status
 ) {
-
+    public static ErrorResponse fromDeokhugamException(DeokhugamException e) {
+        return new ErrorResponse(
+            e.getTimestamp(),
+            e.getErrorCode().name(),
+            e.getErrorCode().getMessage(),
+            e.getDetails(),
+            e.getClass().getSimpleName(),
+            e.getErrorCode().getHttpStatus().value()
+        );
+    }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/sprint/deokhugamteam7/exception/GlobalExceptionAdvice.java
@@ -2,11 +2,22 @@ package com.sprint.deokhugamteam7.exception;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 @RequiredArgsConstructor
 @Slf4j
 public class GlobalExceptionAdvice {
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> handleDeokhugamException(DeokhugamException e) {
+        HttpStatus status = e.getErrorCode().getHttpStatus();
+        return ResponseEntity
+            .status(status)
+            .body(ErrorResponse.fromDeokhugamException(e));
+    }
 
 }


### PR DESCRIPTION
## 🚀 PR 제목  
> 전역 예외 처리 개선 및 `DeokhugamException` 기반 `ErrorResponse` 통합 생성 로직 구현  

---

## 📌 개요 (What & Why)

- **무엇을 구현했는가?**  
  전역 예외 처리 시스템을 개선하여, `DeokhugamException` 발생 시 일관된 구조의 `ErrorResponse` 객체를 생성하도록 구현했습니다. 이를 통해 에러 응답 형식을 통합하고, 예외 유형 및 상세 정보를 클라이언트에 명확히 전달할 수 있도록 했습니다.

- **왜 이 작업이 필요한가?**  
  예외 처리 응답이 분산되어 있거나 임의로 구성될 경우, 클라이언트에서 에러 응답을 일관되게 파싱하기 어렵고 유지보수가 복잡해집니다. 또한 예외별로 상세 메시지나 HTTP 상태 코드, 타입 정보 등을 체계적으로 제공해야 디버깅 및 UX 측면에서도 효율적입니다. 이에 따라 `DeokhugamException`을 중심으로 예외 구조를 통합하고, 응답 포맷을 표준화했습니다.

---

## 🔍 주요 변경 사항 (What was changed)

- `ErrorCode` enum 정의 및 `HttpStatus`, 메시지, 비즈니스 코드 포함 구조 설계  
  - `INTERNAL_SERVER_ERROR`, `NOTIFICATION_NOT_FOUND`, `NOTIFICATION_NOT_OWNED` 코드 추가  

- `DeokhugamException` 구현  
  - `ErrorCode` 및 발생 시각(`timestamp`) 포함  
  - 선택적으로 `details` 필드 포함 가능 (입력값 오류 등 세부 정보 포함 목적)

- `ErrorResponse` 레코드 객체 구현  
  - 예외 발생 시 응답 구조를 표준화하기 위한 DTO  
  - 정적 팩토리 메서드 `fromDeokhugamException()` 추가로, `DeokhugamException` 기반 응답 객체 생성 통일

- `GlobalExceptionAdvice` 수정  
  - `@ExceptionHandler`에서 `ErrorResponse.fromDeokhugamException()`을 통해 응답 생성  
  - 중복 로직 제거 및 예외 응답 생성 책임을 `ErrorResponse` 내부로 위임

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **예외 응답 구조의 일관성 확보**  
  - 응답 필드(`timestamp`, `code`, `message`, `details`, `exceptionType`, `status`)를 고정된 형식으로 제공하여 클라이언트 측 처리 안정성 향상  
  - 예외 타입(`exceptionType`)은 FQCN 대신 단순 클래스 이름만 사용하여 가독성 및 노출 범위 제어

- **정적 팩토리 메서드 도입 이유**  
  - 예외 응답 생성 책임을 `ErrorResponse`로 위임함으로써 `@ExceptionHandler`의 책임을 단순화  
  - 추후 다른 예외 처리 로직에도 재사용 가능하도록 확장성 고려

- **타입 안전성과 유연성 확보**  
  - `DeokhugamException`만 명시적으로 처리하여, 예상 가능한 예외 흐름만 제한적으로 관리  
  - 필요 시 커스텀 예외 확장 또는 인터페이스 도입 등으로 범용화 가능성 확보
