### PR TITLE
[한성태 | 0603] 알람 예외처리 수정 및 테스트 코드 추가 작성

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/entity/Notification.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/entity/Notification.java
@@ -81,7 +81,7 @@ public class Notification {
 
   public void validateUserAuthorization(UUID userId) {
     if (!this.review.getUser().getId().equals(userId)) {
-      throw new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR);
+      throw new NotificationException(ErrorCode.NOTIFICATION_NOT_OWNED);
     }
   }
 

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/repository/NotificationRepository.java
@@ -8,18 +8,19 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID>,
     NotificationRepositoryCustom {
 
   @Query("SELECT n FROM Notification n WHERE n.user.id = :userId AND n.isDelete = false ")
-  List<Notification> findByUserId(UUID userId);
+  List<Notification> findByUserId(@Param("user_id") UUID userId);
 
   @Modifying
   @Query("UPDATE Notification n SET n.confirmed = true WHERE n.review.user.id = :user_id")
-  void bulkUpdateConfirmed(UUID user_id);
+  void bulkUpdateConfirmed(@Param("user_id") UUID user_id);
 
   @Modifying
   @Query("UPDATE Notification n SET n.isDelete = true  WHERE n.isDelete = false AND n.created_at < :threshold")
-  void softDeleteOldNotifications(LocalDateTime threshold);
+  void softDeleteOldNotifications(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
@@ -47,7 +47,6 @@ public class NotificationServiceImpl implements NotificationService {
 
   @Override
   public void updateAll(UUID userId) {
-    System.out.println("요청 아이디: " + userId);
     userRepository.findById(userId)
         .orElseThrow(() -> new UserException(ErrorCode.INTERNAL_SERVER_ERROR));
     notificationRepository.bulkUpdateConfirmed(userId);

--- a/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImpl.java
@@ -10,6 +10,7 @@ import com.sprint.deokhugamteam7.domain.notification.service.NotificationService
 import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
 import com.sprint.deokhugamteam7.exception.ErrorCode;
 import com.sprint.deokhugamteam7.exception.notification.NotificationException;
+import com.sprint.deokhugamteam7.exception.user.UserException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,21 +34,22 @@ public class NotificationServiceImpl implements NotificationService {
       NotificationUpdateRequest request) {
 
     Notification notification = notificationRepository.findById(notificationId)
-        .orElseThrow(() -> new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR));
+        .orElseThrow(() -> new NotificationException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+    userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(ErrorCode.INTERNAL_SERVER_ERROR));
 
     notification.validateUserAuthorization(userId);
-
     notification.updateConfirmed(request.confirmed());
 
-    NotificationDto result = NotificationDto.fromEntity(notification);
-
-    return result;
+    return NotificationDto.fromEntity(notification);
   }
 
   @Override
   public void updateAll(UUID userId) {
+    System.out.println("요청 아이디: " + userId);
     userRepository.findById(userId)
-        .orElseThrow(() -> new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR));
+        .orElseThrow(() -> new UserException(ErrorCode.INTERNAL_SERVER_ERROR));
     notificationRepository.bulkUpdateConfirmed(userId);
   }
 
@@ -55,7 +57,7 @@ public class NotificationServiceImpl implements NotificationService {
   @Transactional(readOnly = true)
   public CursorPageResponseNotificationDto findAll(NotificationCursorRequest request) {
     userRepository.findById(request.userId())
-        .orElseThrow(() -> new NotificationException(ErrorCode.INTERNAL_SERVER_ERROR));
+        .orElseThrow(() -> new UserException(ErrorCode.INTERNAL_SERVER_ERROR));
 
     Slice<NotificationDto> sliceNotificationDto = notificationRepository.findAllByCursor(request);
     long totalElements = notificationRepository.countAllById(request.userId());

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/entity/NotificationTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/entity/NotificationTest.java
@@ -76,7 +76,7 @@ class NotificationTest {
     void validateUserAuthorization_fail() {
         assertThatThrownBy(() -> notification.validateUserAuthorization(OTHER_USER_ID))
             .isInstanceOf(NotificationException.class)
-            .hasMessageContaining(ErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+            .hasMessageContaining(ErrorCode.NOTIFICATION_NOT_OWNED.getMessage());
     }
 
     private void setPrivateField(Object target, String fieldName, Object value) {

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/service/impl/NotificationServiceImplTest.java
@@ -2,6 +2,7 @@ package com.sprint.deokhugamteam7.domain.notification.service.impl;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -12,6 +13,9 @@ import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
 import com.sprint.deokhugamteam7.domain.notification.repository.NotificationRepository;
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
+import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
+import com.sprint.deokhugamteam7.exception.notification.NotificationException;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,6 +36,9 @@ class NotificationServiceImplTest {
     @Mock
     private NotificationRepository notificationRepository;
 
+    @Mock
+    private UserRepository userRepository;
+
     private final UUID NOTIFICATION_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
     private final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
     private final UUID OTHER_USER_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
@@ -40,6 +47,7 @@ class NotificationServiceImplTest {
     private User otherUser;
     private Review review;
     private Notification notification;
+    private NotificationUpdateRequest request;
 
     @BeforeEach
     void setup() {
@@ -56,21 +64,34 @@ class NotificationServiceImplTest {
 
         notification = Notification.create(user, review, "테스트 알림");
         setPrivateField(notification, "id", NOTIFICATION_ID);
+
+        request = new NotificationUpdateRequest(true);
     }
 
     @Test
     @DisplayName("알림 수정 성공 - confirmed 수정 확인")
     void 알림_수정_성공() {
         // given
-        NotificationUpdateRequest request = new NotificationUpdateRequest(true);
-
         given(notificationRepository.findById(any())).willReturn(Optional.of(notification));
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
 
         // when
         NotificationDto result = notificationService.update(NOTIFICATION_ID, USER_ID, request);
 
         // then
         assertThat(result.confirmed()).isTrue();
+    }
+
+    @Test
+    @DisplayName(("알림 수정 실패 - NOTIFICATION_NOT_FOUND"))
+    void notificationNotFoundById() {
+        // given
+        given(notificationRepository.findById(notification.getId())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> notificationService.update(notification.getId(), user.getId(), request))
+            .isInstanceOf(NotificationException.class)
+            .hasMessageContaining(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage());
     }
 
 


### PR DESCRIPTION
## 🚀 PR 제목  
알림 수정 시 예외처리 도입 및 권한 검사 테스트 추가

---

## 📌 개요 (What & Why)

- **무엇을 구현했는가?**  
  알림 수정 기능에서 발생 가능한 예외 상황에 대해 도메인 기반 예외처리를 도입하고, 이에 대한 테스트를 추가했습니다.  
  존재하지 않는 알림 접근 또는 알림 작성자가 아닌 사용자의 수정 요청에 대해 명확한 예외가 발생하도록 처리했습니다.

- **왜 이 작업이 필요한가?**  
  기존에는 모든 예외 상황이 `INTERNAL_SERVER_ERROR`로 처리되어 클라이언트 측에서 문제 원인을 파악하기 어려웠습니다.  
  도메인 특화 예외 코드 도입을 통해 문제 상황을 명확히 구분하고, 프론트엔드 측 에러 핸들링의 정합성과 사용자 경험을 개선했습니다.  
  또한, 알림 소유자 검증 로직에 대한 테스트가 부재해 신뢰성이 낮았던 부분을 테스트 코드로 보완했습니다.

---

## 🔍 주요 변경 사항 (What was changed)

- `NotificationService#update()` 메서드  
  - 알림 조회 실패 시 `NotificationException` 예외 발생 (`NOTIFICATION_NOT_FOUND`)  
  - 알림 소유자 검증 로직 추가 (`validateUserAuthorization()` 호출)  

- `Notification#validateUserAuthorization(UUID userId)` 메서드  
  - 요청자 ID와 작성자 ID가 불일치할 경우 `NotificationException` 발생 (`NOTIFICATION_NOT_OWNED`)

- 테스트 코드 추가  및 수정
  - 존재하지 않는 알림 ID 요청 시 예외 발생 테스트 (`notificationNotFoundById()`)  
  - 알림 작성자와 요청자 불일치 시 예외 발생 테스트 (`validateUserAuthorization_fail()`)

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **도메인 중심 예외 설계**  
  알림 기능 특화 예외 코드를 정의하여, 에러 상황을 명확히 식별하고 REST API 설계 원칙에 부합하는 상태 코드를 사용했습니다.  
  이를 통해 유지보수성과 클라이언트 측의 오류 처리 효율성을 높였습니다.

- **도메인 책임 위임**  
  알림 소유자 검증 로직을 `Notification` 엔티티 내 `validateUserAuthorization()`에 위임하여 도메인 주도 설계를 적용했습니다.  
  이는 도메인 객체가 자신의 상태를 스스로 검사하게 하여, 서비스 레이어의 책임 분리를 강화합니다.

- **테스트 안정성 보강**  
  주요 예외 흐름에 대한 테스트 케이스를 추가함으로써 회귀 테스트를 통한 안정성 확보와 추후 리팩터링 시 안전장치를 마련했습니다.
