### PR TITLE
Feat/56 review popular

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/comment/entity/Comment.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/comment/entity/Comment.java
@@ -18,6 +18,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -30,46 +32,46 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class Comment {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.UUID)
-	private UUID id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID id;
 
-	@ManyToOne
-	@JoinColumn(name = "user_id", nullable = false)
-	private User user;
+  @ManyToOne
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
 
-	@Setter
-	@ManyToOne
-	@JoinColumn(name = "review_id", nullable = false)
-	private Review review;
+  @Setter
+  @ManyToOne
+  @JoinColumn(name = "review_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private Review review;
 
-	@Column(nullable = false)
-	private String content;
+  @Column(nullable = false)
+  private String content;
 
-	private Boolean isDeleted = false;
+  private Boolean isDeleted = false;
 
-	@CreatedDate
-	private LocalDateTime createdAt;
+  @CreatedDate
+  private LocalDateTime createdAt;
 
-	@LastModifiedDate
-	private LocalDateTime updatedAt;
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
 
-	public static Comment create(User user, Review review, String content) {
-		Comment comment = new Comment();
-		comment.user = user;
-		// comment.review = review;
-		comment.content = content;
+  public static Comment create(User user, Review review, String content) {
+    Comment comment = new Comment();
+    comment.user = user;
+    comment.review = review;
+    comment.content = content;
 
-		comment.isDeleted = false;
-		review.addComment(comment);
-		return comment;
-	}
+    comment.isDeleted = false;
+    return comment;
+  }
 
-	public void update(String content) {
-		this.content = content;
-	}
+  public void update(String content) {
+    this.content = content;
+  }
 
-	public void delete() {
-		isDeleted = true;
-	}
+  public void delete() {
+    isDeleted = true;
+  }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/controller/ReviewController.java
@@ -1,8 +1,10 @@
 package com.sprint.deokhugamteam7.domain.review.controller;
 
+import com.sprint.deokhugamteam7.domain.review.dto.request.RankingReviewRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.response.CursorPageResponsePopularReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.CursorPageResponseReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewLikeDto;
@@ -86,5 +88,12 @@ public class ReviewController {
       @RequestHeader(value = "Deokhugam-Request-User-ID") UUID headerUserId) {
     CursorPageResponseReviewDto reviewDto = reviewService.findAll(condition, headerUserId);
     return ResponseEntity.ok(reviewDto);
+  }
+
+  @GetMapping("/popular")
+  public ResponseEntity<CursorPageResponsePopularReviewDto> popular(
+      RankingReviewRequest request) {
+    CursorPageResponsePopularReviewDto popularReviewDto = reviewService.popular(request);
+    return ResponseEntity.ok(popularReviewDto);
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/ReviewCountDto.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/ReviewCountDto.java
@@ -1,0 +1,10 @@
+package com.sprint.deokhugamteam7.domain.review.dto;
+
+import java.util.UUID;
+
+public record ReviewCountDto(
+    UUID reviewId,
+    Long count
+) {
+
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/request/RankingReviewRequest.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/request/RankingReviewRequest.java
@@ -1,0 +1,17 @@
+package com.sprint.deokhugamteam7.domain.review.dto.request;
+
+import com.sprint.deokhugamteam7.constant.Period;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RankingReviewRequest {
+
+  private Period period = Period.DAILY;
+  private String direction = "ASC";
+  private String cursor;
+  LocalDateTime after;
+  int limit = 50;
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/response/PopularReviewDto.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/dto/response/PopularReviewDto.java
@@ -1,9 +1,13 @@
 package com.sprint.deokhugamteam7.domain.review.dto.response;
 
 import com.sprint.deokhugamteam7.constant.Period;
+import com.sprint.deokhugamteam7.domain.review.entity.RankingReview;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Builder;
 
+@Builder
 public record PopularReviewDto(
     UUID id,
     UUID reviewId,
@@ -16,10 +20,29 @@ public record PopularReviewDto(
     double reviewRating,
     Period period,
     LocalDateTime createdAt,
-    int rank,
+    long rank,
     double score,
     long likeCount,
     long commentCount
 ) {
 
+  public static PopularReviewDto of(
+      RankingReview rankingReview, Review review, long rank, long likeCount, long commentCount) {
+    return PopularReviewDto.builder()
+        .id(rankingReview.getId())
+        .reviewId(review.getId())
+        .bookId(review.getBook().getId())
+        .bookThumbnailUrl(review.getBook().getThumbnailUrl())
+        .userId(review.getUser().getId())
+        .userNickname(review.getUser().getNickname())
+        .reviewContent(review.getContent())
+        .reviewRating(review.getRating())
+        .period(rankingReview.getPeriod())
+        .createdAt(review.getCreatedAt())
+        .rank(rank)
+        .score(rankingReview.getScore())
+        .likeCount(likeCount)
+        .commentCount(commentCount)
+        .build();
+  }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/RankingReview.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/RankingReview.java
@@ -18,7 +18,8 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -34,25 +35,30 @@ public class RankingReview {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "review_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Review review;
 
   @Column(nullable = false)
-  private Double score;
+  private double score;
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private Period period;
 
-  @CreatedDate
-  @Column(updatable = false, nullable = false)
-  private LocalDateTime createdAt;
+  @Column(nullable = false)
+  private LocalDateTime reviewCreatedAt;
 
   public static RankingReview create(Review review, Double score, Period period) {
     RankingReview ranking = new RankingReview();
     ranking.review = review;
     ranking.score = score;
     ranking.period = period;
+    ranking.reviewCreatedAt = review.getCreatedAt();
 
     return ranking;
+  }
+
+  public void update(Double score) {
+    this.score = score;
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/Review.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/Review.java
@@ -2,11 +2,9 @@ package com.sprint.deokhugamteam7.domain.review.entity;
 
 
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
-import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
 import com.sprint.deokhugamteam7.domain.user.entity.User;
 import com.sprint.deokhugamteam7.exception.ErrorCode;
 import com.sprint.deokhugamteam7.exception.review.ReviewException;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -16,11 +14,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -64,12 +59,6 @@ public class Review {
   @Column(updatable = false)
   private LocalDateTime updatedAt;
 
-  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<Comment> commentList;
-
-  @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<ReviewLike> reviewLikeList;
-
   public static Review create(Book book, User user, String content, int rating) {
     Review review = new Review();
     review.book = book;
@@ -77,20 +66,8 @@ public class Review {
     review.content = content;
     review.rating = rating;
     review.isDeleted = false;
-    review.commentList = new ArrayList<>();
-    review.reviewLikeList = new ArrayList<>();
 
     return review;
-  }
-
-  public void addComment(Comment comment) {
-    commentList.add(comment);
-    comment.setReview(this);
-  }
-
-  public void addReviewLike(ReviewLike reviewLike) {
-    reviewLikeList.add(reviewLike);
-    reviewLike.setReview(this);
   }
 
   public void delete() {

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/ReviewLike.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/entity/ReviewLike.java
@@ -17,6 +17,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -38,6 +40,7 @@ public class ReviewLike {
   @Setter
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "review_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Review review;
 
   @CreatedDate
@@ -47,10 +50,9 @@ public class ReviewLike {
   public static ReviewLike create(User user, Review review) {
     ReviewLike reviewLike = new ReviewLike();
     reviewLike.user = user;
+    reviewLike.review = review;
 
-    review.addReviewLike(reviewLike);
     return reviewLike;
   }
-
 
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/RankingReviewRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/RankingReviewRepository.java
@@ -1,0 +1,13 @@
+package com.sprint.deokhugamteam7.domain.review.repository;
+
+import com.sprint.deokhugamteam7.constant.Period;
+import com.sprint.deokhugamteam7.domain.review.entity.RankingReview;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RankingReviewRepository extends JpaRepository<RankingReview, UUID> {
+
+  Optional<RankingReview> findByReviewAndPeriod(Review review, Period period);
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryCustom.java
@@ -1,12 +1,26 @@
 package com.sprint.deokhugamteam7.domain.review.repository;
 
+import com.sprint.deokhugamteam7.constant.Period;
+import com.sprint.deokhugamteam7.domain.review.dto.request.RankingReviewRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
+import com.sprint.deokhugamteam7.domain.review.entity.RankingReview;
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 public interface ReviewRepositoryCustom {
 
   List<Review> findAll(ReviewSearchCondition condition, int limit);
 
   long countByCondition(ReviewSearchCondition condition);
+
+  Map<UUID, Long> findLikeCountsByPeriod(LocalDateTime start, LocalDateTime end);
+
+  Map<UUID, Long> findCommentCountsByPeriod(LocalDateTime start, LocalDateTime end);
+
+  List<RankingReview> findRankingReviewsByPeriod(RankingReviewRequest request, int limit);
+
+  long countRakingReviewByPeriod(Period period);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImpl.java
@@ -1,32 +1,46 @@
 package com.sprint.deokhugamteam7.domain.review.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.deokhugamteam7.constant.Period;
 import com.sprint.deokhugamteam7.domain.book.entity.QBook;
+import com.sprint.deokhugamteam7.domain.comment.entity.QComment;
+import com.sprint.deokhugamteam7.domain.review.dto.ReviewCountDto;
+import com.sprint.deokhugamteam7.domain.review.dto.request.RankingReviewRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
+import com.sprint.deokhugamteam7.domain.review.entity.QRankingReview;
 import com.sprint.deokhugamteam7.domain.review.entity.QReview;
+import com.sprint.deokhugamteam7.domain.review.entity.QReviewLike;
+import com.sprint.deokhugamteam7.domain.review.entity.RankingReview;
 import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import com.sprint.deokhugamteam7.domain.user.entity.QUser;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@RequiredArgsConstructor
 public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
-  @PersistenceContext
-  private EntityManager em;
+  private final JPAQueryFactory queryFactory;
+
+  QReview review = QReview.review;
+  QUser user = QUser.user;
+  QBook book = QBook.book;
+  QReviewLike rl = QReviewLike.reviewLike;
+  QComment c = QComment.comment;
+  QRankingReview rankingReview = QRankingReview.rankingReview;
 
   @Override
   public List<Review> findAll(ReviewSearchCondition condition, int limit) {
-    QReview review = QReview.review;
-    QUser user = QUser.user;
-    QBook book = QBook.book;
-
-    JPAQuery<Review> query = new JPAQueryFactory(em)
+    JPAQuery<Review> query = queryFactory
         .selectFrom(review)
         .join(review.user, user).fetchJoin()
         .join(review.book, book).fetchJoin();
@@ -77,8 +91,6 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
   }
 
   public long countByCondition(ReviewSearchCondition condition) {
-    QReview review = QReview.review;
-
     BooleanBuilder where = new BooleanBuilder();
 
     if (condition.getUserId() != null) {
@@ -97,7 +109,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
       );
     }
 
-    Long res = new JPAQueryFactory(em)
+    Long res = queryFactory
         .select(review.count())
         .from(review)
         .where(where)
@@ -105,4 +117,86 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
 
     return res != null ? res : 0;
   }
+
+  @Override
+  public Map<UUID, Long> findLikeCountsByPeriod(LocalDateTime start, LocalDateTime end) {
+    BooleanBuilder builder = new BooleanBuilder();
+    if (start != null && end != null) {
+      builder.and(rl.createdAt.between(start, end));
+    }
+
+    List<ReviewCountDto> likeCounts = queryFactory
+        .select(Projections.constructor(ReviewCountDto.class, rl.review.id, rl.count()))
+        .from(rl)
+        .join(rl.review, review).fetchJoin()
+        .where(builder.and(review.isDeleted.eq(false)))
+        .groupBy(rl.review.id)
+        .fetch();
+
+    return likeCounts.stream()
+        .collect(Collectors.toMap(
+            ReviewCountDto::reviewId, ReviewCountDto::count
+        ));
+  }
+
+  @Override
+  public Map<UUID, Long> findCommentCountsByPeriod(LocalDateTime start, LocalDateTime end) {
+    BooleanBuilder builder = new BooleanBuilder();
+    if (start != null && end != null) {
+      builder.and(c.createdAt.between(start, end));
+    }
+
+    List<ReviewCountDto> commentCounts = queryFactory
+        .select(Projections.constructor(ReviewCountDto.class, c.review.id, c.count()))
+        .from(c)
+        .join(c.review, review).fetchJoin()
+        .where(
+            builder
+                .and(review.isDeleted.eq(false))
+                .and(c.isDeleted.eq(false))
+        )
+        .groupBy(c.review.id)
+        .fetch();
+
+    return commentCounts.stream()
+        .collect(Collectors.toMap(
+            ReviewCountDto::reviewId, ReviewCountDto::count
+        ));
+  }
+
+  public List<RankingReview> findRankingReviewsByPeriod(RankingReviewRequest request, int limit) {
+    String direction = request.getDirection();
+    OrderSpecifier<?> createdAtOrder = direction.equalsIgnoreCase("ASC")
+        ? rankingReview.reviewCreatedAt.asc()
+        : rankingReview.reviewCreatedAt.desc();
+
+    long offset = request.getCursor() != null
+        ? Long.parseLong(request.getCursor())
+        : 0;
+
+    return queryFactory
+        .selectFrom(rankingReview)
+        .join(rankingReview.review, review).fetchJoin()
+        .join(review.user, user).fetchJoin()
+        .join(review.book, book).fetchJoin()
+        .where(rankingReview.period.eq(request.getPeriod()))
+        .orderBy(
+            rankingReview.score.desc(),
+            createdAtOrder
+        )
+        .offset(offset)
+        .limit(limit + 1)
+        .fetch();
+  }
+
+  public long countRakingReviewByPeriod(Period period) {
+    Long res = queryFactory
+        .select(rankingReview.count())
+        .from(rankingReview)
+        .where(rankingReview.period.eq(period))
+        .fetchOne();
+
+    return res != null ? res : 0;
+  }
 }
+

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/scheduler/PopularReviewScoreSchedule.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/scheduler/PopularReviewScoreSchedule.java
@@ -1,0 +1,63 @@
+package com.sprint.deokhugamteam7.domain.review.scheduler;
+
+import com.sprint.deokhugamteam7.constant.Period;
+import com.sprint.deokhugamteam7.domain.review.entity.RankingReview;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.review.repository.RankingReviewRepository;
+import com.sprint.deokhugamteam7.domain.review.repository.ReviewRepository;
+import com.sprint.deokhugamteam7.domain.review.repository.ReviewRepositoryCustom;
+import com.sprint.deokhugamteam7.exception.ErrorCode;
+import com.sprint.deokhugamteam7.exception.review.ReviewException;
+import jakarta.annotation.Nullable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PopularReviewScoreSchedule {
+
+  private final ReviewRepository reviewRepository;
+  private final ReviewRepositoryCustom reviewRepositoryCustom;
+  private final RankingReviewRepository rankingReviewRepository;
+
+  @Scheduled(cron = "0 0 0 * * *")
+  public void scheduleScore() {
+    LocalDateTime end = LocalDate.now().atStartOfDay();
+    calculateReviewScore(end.minusDays(1), end, Period.DAILY);
+    calculateReviewScore(end.minusWeeks(1), end, Period.WEEKLY);
+    calculateReviewScore(end.minusMonths(1), end, Period.MONTHLY);
+    calculateReviewScore(null, null, Period.ALL_TIME);
+  }
+
+  public void calculateReviewScore
+      (@Nullable LocalDateTime start, @Nullable LocalDateTime end, Period period) {
+    Map<UUID, Long> likeMap = reviewRepositoryCustom.findLikeCountsByPeriod(start, end);
+    Map<UUID, Long> commentMap = reviewRepositoryCustom.findCommentCountsByPeriod(start, end);
+
+    Set<UUID> reviewIds = new HashSet<>();
+    reviewIds.addAll(likeMap.keySet());
+    reviewIds.addAll(commentMap.keySet());
+
+    for (UUID id : reviewIds) {
+      long likes = likeMap.getOrDefault(id, 0L);
+      long comments = commentMap.getOrDefault(id, 0L);
+
+      double score = Math.round(((likes * 0.3) + (comments * 0.7)) * 1000.0) / 1000.0;
+
+      Review review = reviewRepository.findById(id)
+          .orElseThrow(() -> new ReviewException(ErrorCode.INTERNAL_SERVER_ERROR));
+      RankingReview ranking = rankingReviewRepository.findByReviewAndPeriod(review, period)
+          .orElseGet(() -> RankingReview.create(review, score, period));
+
+      ranking.update(score);
+      rankingReviewRepository.save(ranking);
+    }
+  }
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/ReviewService.java
@@ -1,8 +1,10 @@
 package com.sprint.deokhugamteam7.domain.review.service;
 
+import com.sprint.deokhugamteam7.domain.review.dto.request.RankingReviewRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewCreateRequest;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
 import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewUpdateRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.response.CursorPageResponsePopularReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.CursorPageResponseReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewDto;
 import com.sprint.deokhugamteam7.domain.review.dto.response.ReviewLikeDto;
@@ -23,4 +25,6 @@ public interface ReviewService {
   ReviewLikeDto like(UUID id, UUID userId);
 
   CursorPageResponseReviewDto findAll(ReviewSearchCondition condition, UUID headerUserId);
+
+  CursorPageResponsePopularReviewDto popular(RankingReviewRequest request);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/repository/impl/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/repository/impl/UserQueryRepositoryImpl.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class UserQueryRepositoryImpl implements UserQueryRepository {
+
   private final JPAQueryFactory queryFactory;
 
   private final QUserScore userScore = QUserScore.userScore;
@@ -86,7 +87,7 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
         .select(rankingReview.review.user.id, rankingReview.score.sum())
         .from(rankingReview)
         .where(rankingReview.period.eq(period),
-            rankingReview.createdAt.between(start, end.minusNanos(1)))
+            rankingReview.reviewCreatedAt.between(start, end.minusNanos(1)))
         .groupBy(rankingReview.review.user.id)
         .fetch()
         .stream()

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,17 +11,17 @@ create table if not exists users
 
 create table if not exists user_score
 (
-    id         UUID PRIMARY KEY,
-    user_id    UUID        NOT NULL,
-    period VARCHAR(20) NOT NULL CHECK (period IN ('DAILY', 'WEEKLY', 'MONTHLY', 'ALL_TIME')),
-    created_at TIMESTAMP   NOT NULL,
-    score DOUBLE PRECISION NOT NULL,
+    id               UUID PRIMARY KEY,
+    user_id          UUID             NOT NULL,
+    period           VARCHAR(20)      NOT NULL CHECK (period IN ('DAILY', 'WEEKLY', 'MONTHLY', 'ALL_TIME')),
+    created_at       TIMESTAMP        NOT NULL,
+    score            DOUBLE PRECISION NOT NULL,
     review_score_sum DOUBLE PRECISION,
-    like_count BIGINT,
-    comment_count BIGINT,
-    date DATE NOT NULL,
-    rank BIGINT,
-    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    like_count       BIGINT,
+    comment_count    BIGINT,
+    date             DATE             NOT NULL,
+    rank             BIGINT,
+    CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
     CONSTRAINT uq_user_period_date UNIQUE (user_id, period, date)
 );
 
@@ -45,22 +45,22 @@ create table if not exists ranking_books
     id           UUID PRIMARY KEY,
     book_id      UUID,
     rank         BIGINT,
-    period       VARCHAR(255) NOT NULL ,
+    period       VARCHAR(255) NOT NULL,
     score        DOUBLE PRECISION,
     total_rating INTEGER,
     review_count BIGINT,
-    rating        DOUBLE PRECISION,
+    rating       DOUBLE PRECISION,
     CONSTRAINT uk_book_period UNIQUE (book_id, period),
     constraint fk_ranking_book foreign key (book_id) references books (id) on delete cascade
 );
 
 create table if not exists reviews
 (
-    id         UUID      PRIMARY KEY,
+    id         UUID PRIMARY KEY,
     user_id    UUID      NOT NULL,
     book_id    UUID      NOT NULL,
     content    TEXT      NOT NULL,
-    rating INT NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    rating     INT       NOT NULL CHECK (rating BETWEEN 1 AND 5),
     is_deleted BOOLEAN   NOT NULL,
     created_at TIMESTAMP NOT NULL,
     updated_at TIMESTAMP,
@@ -72,7 +72,7 @@ create table if not exists reviews
 
 create table if not exists review_likes
 (
-    id         UUID      PRIMARY KEY,
+    id         UUID PRIMARY KEY,
     user_id    UUID      NOT NULL,
     review_id  UUID      NOT NULL,
     created_at TIMESTAMP NOT NULL,
@@ -84,28 +84,30 @@ create table if not exists review_likes
 
 create table if not exists ranking_reviews
 (
-    id         UUID             PRIMARY KEY,
-    review_id  UUID             NOT NULL,
-    score      DOUBLE PRECISION NOT NULL,
-    period     VARCHAR(20)      NOT NULL CHECK (period IN ('DAILY', 'WEEKLY', 'MONTHLY', 'ALL_TIME')),
-    created_at TIMESTAMP        NOT NULL,
+    id                UUID PRIMARY KEY,
+    review_id         UUID             NOT NULL,
+    score             DOUBLE PRECISION NOT NULL,
+    period            VARCHAR(20)      NOT NULL CHECK (period IN ('DAILY', 'WEEKLY', 'MONTHLY', 'ALL_TIME')),
+    review_created_at TIMESTAMP        NOT NULL,
 
-    CONSTRAINT fk_rankingreviews_review FOREIGN KEY (review_id) REFERENCES reviews (id) ON DELETE CASCADE
---     CONSTRAINT uk_reviewlikes_user_review UNIQUE (user_id, review_id)
+    CONSTRAINT fk_rankingreviews_review FOREIGN KEY (review_id) REFERENCES reviews (id) ON DELETE CASCADE,
+    CONSTRAINT uk_rankingreviews_review_period UNIQUE (review_id, period)
 );
+
+CREATE INDEX idx_ranking_period_score ON ranking_reviews (period, score DESC);
 
 create table if not exists comments
 (
     id         UUID PRIMARY KEY,
-    user_id    UUID             NOT NULL,
-    review_id  UUID             NOT NULL,
-    content    VARCHAR(255)     NOT NULL,
-    is_deleted BOOLEAN          NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMP        NOT NULL,
+    user_id    UUID         NOT NULL,
+    review_id  UUID         NOT NULL,
+    content    VARCHAR(255) NOT NULL,
+    is_deleted BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP    NOT NULL,
     updated_at TIMESTAMP,
 
-    CONSTRAINT fk_comment_user   FOREIGN KEY (user_id)   REFERENCES users   (id)  ON DELETE CASCADE,
-    CONSTRAINT fk_comment_review FOREIGN KEY (review_id) REFERENCES reviews (id)  ON DELETE CASCADE
+    CONSTRAINT fk_comment_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+    CONSTRAINT fk_comment_review FOREIGN KEY (review_id) REFERENCES reviews (id) ON DELETE CASCADE
 );
 
 create table if not exists notifications


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?
사용자가 일간, 주간, 월간, 역대 기준으로 인기 리뷰 목록을 확인할 수 있는 기능을 구현했습니다.
리뷰 인기 순위는 좋아요 수와 댓글 수를 기반으로 점수를 계산하며, 해당 점수는 배치 작업을 통해 주기적으로 저장됩니다.
클라이언트는 인기 리뷰 목록을 오프셋 기반으로 페이지네이션하여 요청할 수 있습니다.

왜 이 작업이 필요한가?
인기 리뷰 기능은 사용자에게 유의미한 콘텐츠를 우선적으로 보여주는 핵심 기능입니다.
점수를 별도 테이블에 저장하고 배치로 연산함으로써, 실시간 집계 비용을 줄이고 응답 속도와 시스템 확장성을 확보했습니다.

- 프로토타입을 보니, 요청과 응답의 cursor가 score이 아닌 rank이기에, 커서 기반 페이지네이션이 불가능하다고 보았습니다. 따라서 rank를 사용한 오프셋 기반의 페이지네이션으로 구현하였습니다.

🔍 주요 변경 사항 (What was changed)
✅ 초기 설정 변경점
1. schema.sql :
- RankingReview의 복합 인덱스를 추가해줌. (period, score DESC) - 조회 성능을 위해서.
- review_id와 period를 유니크로 둠.

2. Review :  
- Review에서 Comment와 ReviewLike를 List로 저장하지 않음
- 대신 Comment와 ReviewLike에서 @OnDelete를 추가하여 연쇄삭제가 가능하도록 바꿈. (RankingReview도 동일)
- ➕ Comment부분은 구글 코드 스타일설정으로 인해 띄어쓰기 부분까지 변경되었습니다.. 바꾼다고 바꿨는데 저장하면서 원래대로 돌아왔어요..

3. RankingReview  : 
- createdAt -> reviewCreatedAt으로 변경. 기존 createdAt은 랭킹리뷰의 생성날짜를 가졌으나, 사용할 곳이 없었고 정렬에서 score가 동일할 시 먼저 작성된 리뷰를 위쪽에 두어야 하여 
review의 createdAt을 저장하는 필드로 바꾸게 됨.
   => UserQueryRepositoryImpl의 rankingReview의 createdAt도 reviewCreatedAt으로 변경.

4. ReviewRepositoryImpl : 
- JPAQueryFactory를 전역 필드로 두고 사용.
: JPAQueryFactory는 EntitiyManager를 사용해서 쿼리를 실행함. 매번 new하면 EntityManager 주기 관리가 더 복잡해지기 때문에 전역으로 옮김.

---

✅ Controller
ReviewController#popular:
- GET /reviews/popular 경로에 대해 RankingReviewRequest를 통해 요청 처리
- 인기 리뷰 목록을 오프셋 기반으로 응답

✅ Service
ReviewService#popular:
- 기간과 커서 조건에 맞는 인기 리뷰 목록을 조회하는 서비스 메서드 정의

BasicReviewService#popular:
- RankingReview 테이블 기반으로 인기 리뷰 리스트 조회
- 각 리뷰에 대해 좋아요 수, 댓글 수 재집계
- 순위, 메타 정보 포함한 PopularReviewDto 리스트 반환
- 오프셋 기반 페이지네이션 적용 (nextCursor, hasNext, nextAfter 포함)

✅ Repository
RankingReviewRepository:
- 특정 리뷰와 기간 조합으로 랭킹 리뷰 조회

ReviewRepositoryCustom 구현 (ReviewRepositoryImpl):
- findLikeCountsByPeriod(start, end)
- findCommentCountsByPeriod(start, end)
→ 해당 기간 동안의 좋아요, 댓글 수를 집계

- findRankingReviewsByPeriod(request, limit)
→ 점수 기준 정렬된 RankingReview 목록 조회

- countRakingReviewByPeriod(period)
→ 총 인기 리뷰 수 반환

✅ Entity/DTO/기타
RankingReview:
- 리뷰, 점수, 리뷰 생성일, 기간(period)을 기준으로 인기 리뷰 데이터 보관

PopularReviewDto, CursorPageResponsePopularReviewDto:
- 응답 전용 DTO 구성

✅ Batch Schedule
PopularReviewScoreSchedule:
- 매일 자정 @Scheduled(cron = "0 0 0 * * *")로 인기 리뷰 점수 계산
- Period(DAILY, WEEKLY, MONTHLY, ALL_TIME) 단위로 각각 계산

점수 계산식:
- score = (likeCount * 0.3) + (commentCount * 0.7)
- RankingReview 테이블에 저장 또는 갱신

🧩 설계 및 구현 고려사항 (Design decisions)
배치 처리 설계
실시간 점수 계산은 성능 저하를 유발할 수 있으므로, 리뷰 점수 계산은 배치 스케줄러로 처리하였습니다.
이는 랭킹 정확도를 유지하면서도 서비스 응답 속도를 극대화하기 위한 설계입니다.

점수 계산 로직 정밀도 유지
실수 오차 방지를 위해 score는 소수점 세 자리까지 Math.round(... * 1000.0) / 1000.0으로 고정하여 계산하였습니다.
향후 정렬 일관성이나 DTO 변환 시 정확한 값 전달을 보장합니다.

응답 구성
각 PopularReviewDto는 순위 정보를 포함하며, likeCount, commentCount 등의 메타 정보를 포함하여 UI 측면에서도 충분한 표현이 가능하도록 구성했습니다.

재집계 설계 이유
RankingReview에는 점수만 저장되어 있으므로, 각 요청 시점의 최신 좋아요/댓글 수는 응답 시점에 집계하여 클라이언트에 최신 메타 정보를 제공하도록 했습니다.
이는 점수 기반 정렬과 실제 콘텐츠의 최신 상태를 분리해 유지하기 위한 설계입니다.

🚫 스케쥴러 연산으로 인기 리뷰 목록 조회 기능은 테스트를 하지 못하였습니다.. 

close #56 