### PR TITLE
[이종원 | 0604] PR 요약: 이미지 컴포넌트 리팩터링 · 랭킹 로직 개선 · 테스트용 보안 설정 추가

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/entity/RankingBook.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/entity/RankingBook.java
@@ -1,6 +1,7 @@
 package com.sprint.deokhugamteam7.domain.book.entity;
 
 import com.sprint.deokhugamteam7.constant.Period;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -92,6 +94,12 @@ public class RankingBook {
     this.totalRating = 0;
     this.reviewCount = 0;
     this.rating = 0.0;
+  }
+
+  public void reCalculate() {
+    List<Review> reviews = this.book.getReviews();
+    reset();
+    reviews.forEach(review -> update(review.getRating(), false));
   }
 
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/repository/BookRepository.java
@@ -8,9 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface BookRepository extends JpaRepository<Book, UUID> {
 
-  boolean existsByIsbnIsNotNullAndIsbn(String isbn);
-
-  @Query("SELECT b FROM Book b WHERE b.id = :id AND b.isDeleted = false")
+  @Query("SELECT b FROM Book b JOIN FETCH b.rankingBooks WHERE b.id = :id AND b.isDeleted = false")
   Optional<Book> findByIdAndIsDeletedFalse(UUID id);
 
   boolean existsByIsbn(String isbn);

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BasicBookService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BasicBookService.java
@@ -19,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class BasicBookService implements BookService {
 
-  private final ImageService imageService;
+  private final ImageComponent imageComponent;
   private final BookRepository bookRepository;
 
   @Override
@@ -35,7 +35,7 @@ public class BasicBookService implements BookService {
 
     String thumbnailUrl = null;
     if (file != null) {
-      thumbnailUrl = imageService.uploadImage(file);
+      thumbnailUrl = imageComponent.uploadImage(file);
     }
 
     Book book = Book.create(request.title(), request.author(), request.publisher(),
@@ -64,7 +64,7 @@ public class BasicBookService implements BookService {
 
     String thumbnailUrl = null;
     if (file != null) {
-      thumbnailUrl = imageService.uploadImage(file);
+      thumbnailUrl = imageComponent.uploadImage(file);
     }
 
     book.update(request.title(), request.author(), request.description(), request.publisher(),

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/ImageComponent.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/ImageComponent.java
@@ -2,7 +2,7 @@ package com.sprint.deokhugamteam7.domain.book.service;
 
 import org.springframework.web.multipart.MultipartFile;
 
-public interface ImageService {
+public interface ImageComponent {
 
   String uploadImage(MultipartFile file);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/S3ImageComponent.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/S3ImageComponent.java
@@ -17,7 +17,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class S3ImageService implements ImageService {
+public class S3ImageComponent implements ImageComponent {
 
   @Value("${aws.s3.bucket}")
   private String bucketName;

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/localImageComponent.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/localImageComponent.java
@@ -17,11 +17,11 @@ import org.springframework.web.multipart.MultipartFile;
 @ConditionalOnProperty(name = "deokhugam.storage.type", havingValue = "local")
 @Component
 @Slf4j
-public class localImageService implements ImageService {
+public class localImageComponent implements ImageComponent {
 
   private final Path storagePath;
 
-  public localImageService(
+  public localImageComponent(
       @Value("${deokhugam.storage.local.root-path}") String storagePath) {
     this.storagePath = Paths.get(storagePath);
     init();

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/basic/BasicReviewService.java
@@ -96,11 +96,8 @@ public class BasicReviewService implements ReviewService {
 
     review.update(newContent, newRating);
 
-    int diff = beforeRating > newRating ? newRating - beforeRating
-        : beforeRating - newRating;
-
     List<RankingBook> rankingBooks = review.getBook().getRankingBooks();
-    rankingBooks.forEach(rankingBook -> rankingBook.update(diff, false));
+    rankingBooks.forEach(RankingBook::reCalculate);
 
     int likeCount = reviewLikeRepository.countByReviewId(id);
     int commentCount = commentRepository.countByReviewIdAndIsDeletedFalse(id);

--- a/src/test/java/com/sprint/deokhugamteam7/config/TestSecurityConfig.java
+++ b/src/test/java/com/sprint/deokhugamteam7/config/TestSecurityConfig.java
@@ -1,0 +1,17 @@
+package com.sprint.deokhugamteam7.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+public class TestSecurityConfig {
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable());
+    return http.build();
+  }
+}

--- a/src/test/java/com/sprint/deokhugamteam7/domain/book/BookControllerTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/book/BookControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.deokhugamteam7.config.TestSecurityConfig;
 import com.sprint.deokhugamteam7.domain.book.controller.BookController;
 import com.sprint.deokhugamteam7.domain.book.dto.BookDto;
 import com.sprint.deokhugamteam7.domain.book.dto.NaverBookDto;
@@ -26,6 +27,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -33,6 +35,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.multipart.MultipartFile;
 
 @WebMvcTest(BookController.class)
+@Import(TestSecurityConfig.class)
 public class BookControllerTest {
 
   private final UUID BOOK_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");

--- a/src/test/java/com/sprint/deokhugamteam7/domain/book/BookIntegrationTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/book/BookIntegrationTest.java
@@ -11,7 +11,7 @@ import com.sprint.deokhugamteam7.domain.book.dto.request.BookUpdateRequest;
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
 import com.sprint.deokhugamteam7.domain.book.service.BookService;
-import com.sprint.deokhugamteam7.domain.book.service.ImageService;
+import com.sprint.deokhugamteam7.domain.book.service.ImageComponent;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BookIntegrationTest {
 
   @MockitoBean
-  private ImageService imageService;
+  private ImageComponent imageComponent;
 
   @Autowired
   private BookService bookService;

--- a/src/test/java/com/sprint/deokhugamteam7/domain/book/BookServiceUnitTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/book/BookServiceUnitTest.java
@@ -13,7 +13,7 @@ import com.sprint.deokhugamteam7.domain.book.dto.request.BookUpdateRequest;
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
 import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
 import com.sprint.deokhugamteam7.domain.book.service.BasicBookService;
-import com.sprint.deokhugamteam7.domain.book.service.S3ImageService;
+import com.sprint.deokhugamteam7.domain.book.service.S3ImageComponent;
 import com.sprint.deokhugamteam7.exception.DeokhugamException;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -29,7 +29,7 @@ import org.springframework.mock.web.MockMultipartFile;
 public class BookServiceUnitTest {
 
   @Mock
-  private S3ImageService s3ImageService;
+  private S3ImageComponent s3ImageService;
 
   @Mock
   private BookRepository bookRepository;


### PR DESCRIPTION
## 🧑‍💻 PR 요약: 이미지 컴포넌트 리팩터링 · 랭킹 로직 개선 · 테스트용 보안 설정 추가

이번 Pull Request는 **이미지 서비스 컴포넌트의 리네이밍**, **랭킹 계산 로직 개선**, **테스트 환경용 보안 설정** 등을 포함합니다. 주요 변경 사항을 주제별로 정리하면 다음과 같습니다.

---

### 🖼️ 이미지 컴포넌트 리팩터링
* `ImageService` → **`ImageComponent`** 로 명칭을 변경하고, 모든 참조를 수정했습니다.  
  예) `S3ImageService` → `S3ImageComponent`, `localImageService` → `localImageComponent`  
  - 🔗 변경 위치: [[1]](diffhunk://#diff-c52a5254b53386f8d40d5add630861da469f59c27827db912b666bc0c8b283b1L5-R5) [[2]](diffhunk://#diff-c5bb8036b96eb00a08aaf68d02549d935f31689c94673dd9582ff037bfc9ffccL20-R20) [[3]](diffhunk://#diff-56033147c7dc31bfc90589d4f5919a7b5be3aaaf23f7aa50751554d5b60ce2bcL20-R24)
* `BasicBookService`에서 이미지 업로드 시 `ImageComponent`를 사용하도록 변경했습니다.  
  - 🔗 변경 위치: [[1]](diffhunk://#diff-e40c6852e44898af0a46424d28bc5465a31efd9d0b95ad8d612ae5cfb2ba8998L22-R22) [[2]](diffhunk://#diff-e40c6852e44898af0a46424d28bc5465a31efd9d0b95ad8d612ae5cfb2ba8998L38-R38) [[3]](diffhunk://#diff-e40c6852e44898af0a46424d28bc5465a31efd9d0b95ad8d612ae5cfb2ba8998L67-R67)

---

### 📊 랭킹 로직 개선
* `RankingBook`에 **`reCalculate()`** 메서드를 추가하여 리뷰 정보를 기반으로 랭킹을 초기화·재계산하도록 변경했습니다.  
* `BasicReviewService`는 리뷰 업데이트 시 새 `reCalculate()` 메서드를 호출하여 랭킹을 갱신합니다.

---

### ⚡ 저장소 쿼리 최적화
* `BookRepository`의 `findByIdAndIsDeletedFalse` 쿼리에 `JOIN FETCH`를 적용해 `rankingBooks`를 **즉시 로딩(eager loading)**, 랭킹 조회 시 N+1 문제를 완화했습니다.

---

### 🔐 테스트용 보안 설정
* **`TestSecurityConfig`** 클래스를 추가하여 **테스트 환경에서 CSRF 보호를 비활성화**했습니다.
* `BookControllerTest`에 `@Import(TestSecurityConfig.class)`를 추가해 새 보안 설정을 반영했습니다.  
  - 🔗 변경 위치: [[1]](diffhunk://#diff-0840ea93593456fc55d1e2ff6e6eec48ec31b0cc80c1587aa1826dcd8dfe8695R15) [[2]](diffhunk://#diff-0840ea93593456fc55d1e2ff6e6eec48ec31b0cc80c1587aa1826dcd8dfe8695R30-R38)

---

### 🧪 테스트 코드 업데이트
* `BookIntegrationTest`, `BookServiceUnitTest` 등 테스트 파일에서  
  `ImageService` → `ImageComponent` 및 각 구현체(`S3ImageComponent`, `localImageComponent`)로 교체했습니다.  
  - 🔗 변경 위치: [[1]](diffhunk://#diff-2132acbde2124752683cd8894479b874d34c325ab8ebcd067381d49ffcb75c3bL14-R14) [[2]](diffhunk://#diff-2132acbde2124752683cd8894479b874d34c325ab8ebcd067381d49ffcb75c3bL30-R30) [[3]](diffhunk://#diff-fb0c23d6ce5a28ff9ec6535d367873ef6e322703351d9c435db0ba261e88c8a6L16-R16) [[4]](diffhunk://#diff-fb0c23d6ce5a28ff9ec6535d367873ef6e322703351d9c435db0ba261e88c8a6L32-R32)

---
