### PR TITLE
Test/74 review repository test

### DIFF
--- a/src/test/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewAndReviewLikeRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewAndReviewLikeRepositoryTest.java
@@ -1,0 +1,97 @@
+package com.sprint.deokhugamteam7.domain.review.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.notification.config.TestConfig;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.review.entity.ReviewLike;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@Import(TestConfig.class)
+@DataJpaTest
+@ActiveProfiles("test")
+public class ReviewAndReviewLikeRepositoryTest {
+
+  @Autowired
+  private ReviewRepository reviewRepository;
+
+  @Autowired
+  private ReviewLikeRepository reviewLikeRepository;
+
+  @Autowired
+  private EntityManager em;
+
+  private User user;
+  private Book book;
+  private Review review;
+  private final String content = "리뷰입니다.";
+  private final int rating = 3;
+
+  @BeforeEach
+  void setUp() {
+    user = User.create("test@gmail.com", "test1", "test1234!");
+    book = Book.create("test", "test", "test",
+        LocalDate.of(2020, 1, 15)).build();
+    review = Review.create(book, user, content, rating);
+
+    em.persist(user);
+    em.persist(book);
+    em.persist(review);
+    em.flush();
+    em.clear();
+  }
+
+  // ReviewRepository
+
+  @Test
+  @DisplayName("리뷰 조회 시 User와 Book을 Fetch Join으로 함께 조회")
+  void findByIdWithUserAndBook_shouldFetchUserAndBook() {
+    Optional<Review> res = reviewRepository.findByIdWithUserAndBook(review.getId());
+
+    assertThat(res).isPresent();
+    assertThat(res.get().getUser().getId()).isEqualTo(user.getId());
+    assertThat(res.get().getBook().getId()).isEqualTo(book.getId());
+  }
+
+  // ReviewLikeRepository
+
+  @Test
+  @DisplayName("리뷰의 좋아요 수 조회")
+  void countByReviewId_shouldReturnCount() {
+    User user2 = User.create("test2@gmail.com", "test2", "test1234!");
+    em.persist(user2);
+
+    ReviewLike like1 = ReviewLike.create(user, review);
+    ReviewLike like2 = ReviewLike.create(user2, review);
+    em.persist(like1);
+    em.persist(like2);
+    em.flush();
+
+    int res = reviewLikeRepository.countByReviewId(review.getId());
+
+    assertThat(res).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("유저가 특정 리뷰에 좋아요를 누른 경우 true를 반환")
+  void existsByUserIdAndReviewId_ShouldReturnTrue() {
+    ReviewLike like1 = ReviewLike.create(user, review);
+    em.persist(like1);
+    em.flush();
+
+    boolean res = reviewLikeRepository.existsByUserIdAndReviewId(user.getId(), review.getId());
+
+    assertThat(res).isTrue();
+  }
+}

--- a/src/test/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImplTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImplTest.java
@@ -243,7 +243,7 @@ public class ReviewRepositoryImplTest {
 
   @Test
   @DisplayName("해당 기간의 모든 랭킹리뷰 조회")
-  void countRakingReviewByPeriod_ShouldReturnCountWithinPeriod() {
+  void countRankingReviewByPeriod_ShouldReturnCountWithinPeriod() {
     createOtherReviews();
 
     RankingReview ranking1 = RankingReview.create(review, 9.0, Period.DAILY);

--- a/src/test/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImplTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImplTest.java
@@ -1,0 +1,300 @@
+package com.sprint.deokhugamteam7.domain.review.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sprint.deokhugamteam7.constant.Period;
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
+import com.sprint.deokhugamteam7.domain.notification.config.TestConfig;
+import com.sprint.deokhugamteam7.domain.review.dto.request.RankingReviewRequest;
+import com.sprint.deokhugamteam7.domain.review.dto.request.ReviewSearchCondition;
+import com.sprint.deokhugamteam7.domain.review.entity.RankingReview;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.review.entity.ReviewLike;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@Import(TestConfig.class)
+@DataJpaTest
+@ActiveProfiles("test")
+public class ReviewRepositoryImplTest {
+
+  @Autowired
+  private ReviewRepositoryCustom reviewRepositoryCustom;
+
+  @Autowired
+  private EntityManager em;
+
+  @Autowired
+  private JPAQueryFactory jpaQueryFactory;
+
+  private User user;
+  private User user2;
+  private User user3;
+  private User user4;
+  private Book book;
+  private Book book2;
+  private Review review;
+  private Review review2;
+  private Review review3;
+  private Review review4;
+
+  private final int rating = 3;
+
+  private final LocalDateTime day = LocalDateTime.of(2025, 6, 4, 3, 0);
+  private final LocalDateTime week = LocalDateTime.of(2025, 5, 30, 3, 0);
+  private final LocalDateTime month = LocalDateTime.of(2025, 5, 10, 3, 0);
+  private final LocalDateTime allTime = LocalDateTime.of(2024, 6, 4, 4, 0);
+  private final LocalDateTime end = LocalDate.of(2025, 6, 5).atStartOfDay();
+
+  @BeforeEach
+  void setUp() {
+    user = User.create("test@gmail.com", "test1", "test1234!");
+    book = Book.create("테스트", "test", "test",
+        LocalDate.of(2020, 1, 15)).build();
+    review = Review.create(book, user, "리뷰1", rating);
+
+    em.persist(user);
+    em.persist(book);
+    em.persist(review);
+    em.flush();
+  }
+
+  @Test
+  @DisplayName("검색 조건과 정렬 조건, 제한에 맞는 리뷰를 조회")
+  void findAll_ShouldReturnReviewList() {
+    ReviewSearchCondition condition = createSearchCondition();
+
+    createOtherReviews();
+
+    List<Review> res = reviewRepositoryCustom.findAll(condition, condition.getLimit());
+    // - DESC 조회, 키워드는 유저의 닉네임 or 책의 제목 or 리뷰의 내용 중 하나라도 일치하면 포함됨.
+    // - isDeleted가 false 이어야 함. limit + 1개의 List가 반환되어야 함.
+
+    assertThat(res).hasSize(2);
+    assertThat(res).hasSizeLessThanOrEqualTo(condition.getLimit() + 1);
+    assertThat(res.get(0).getId()).isEqualTo(review2.getId());
+    assertThat(res.get(0).getContent()).isEqualTo("리뷰2");
+    assertThat(res.get(1).getContent()).isEqualTo("리뷰1");
+    assertThat(res).noneMatch(review -> review.getId().equals(review3.getId()));
+    assertThat(res).noneMatch(review -> review.getId().equals(review4.getId()));
+  }
+
+  @Test
+  @DisplayName("검색 조건과 정렬 조건, 제한에 맞는 모든 리뷰의 수 반환")
+  void countByCondition_ShouldReturnReviewCount() {
+    ReviewSearchCondition condition = createSearchCondition();
+    createOtherReviews();
+
+    long res = reviewRepositoryCustom.countByCondition(condition);
+
+    assertThat(res).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("리뷰별 좋아요 수를 기간별로 집계")
+  void findLikeCountsByPeriod_ShouldReturnCountMapWithinPeriod() {
+    createOtherReviews();
+    ReflectionTestUtils.setField(review4, "isDeleted", false);
+
+    ReviewLike like1 = ReviewLike.create(user, review);
+    ReviewLike like2 = ReviewLike.create(user, review2);
+    ReviewLike like3 = ReviewLike.create(user2, review2);
+    ReviewLike like4 = ReviewLike.create(user, review3);
+    ReviewLike like5 = ReviewLike.create(user, review4);
+    ReviewLike like6 = ReviewLike.create(user2, review4);
+    em.persist(like1);
+    em.persist(like2);
+    em.persist(like3);
+    em.persist(like4);
+    em.persist(like5);
+    em.persist(like6);
+
+    updateReviewLikeCreatedAt(day, like1.getId());
+    updateReviewLikeCreatedAt(week, like2.getId());
+    updateReviewLikeCreatedAt(week, like3.getId());
+    updateReviewLikeCreatedAt(month, like4.getId());
+    updateReviewLikeCreatedAt(allTime, like5.getId());
+    updateReviewLikeCreatedAt(allTime, like6.getId());
+    em.flush();
+    em.clear();
+
+    Map<UUID, Long> dayRes = reviewRepositoryCustom.findLikeCountsByPeriod(end.minusDays(1), end);
+    Map<UUID, Long> weekRes = reviewRepositoryCustom.findLikeCountsByPeriod(end.minusWeeks(1), end);
+    Map<UUID, Long> monthRes = reviewRepositoryCustom.findLikeCountsByPeriod(end.minusMonths(1),
+        end);
+    Map<UUID, Long> allRes = reviewRepositoryCustom.findLikeCountsByPeriod(null, null);
+
+    assertThat(dayRes).hasSize(1);
+    assertThat(dayRes.get(review.getId())).isEqualTo(1L);
+    assertThat(weekRes).hasSize(2);
+    assertThat(weekRes.get(review2.getId())).isEqualTo(2L);
+    assertThat(monthRes).hasSize(3);
+    assertThat(monthRes.get(review3.getId())).isEqualTo(1L);
+    assertThat(allRes).hasSize(4);
+    assertThat(allRes.get(review4.getId())).isEqualTo(2L);
+  }
+
+  ReviewSearchCondition createSearchCondition() {
+    ReviewSearchCondition condition = new ReviewSearchCondition();
+    condition.setUserId(null);
+    condition.setBookId(null);
+    condition.setKeyword("테스트");
+    condition.setOrderBy("createdAt");
+    condition.setDirection("DESC");
+    condition.setLimit(1);
+    condition.setRequestUserId(user.getId());
+
+    return condition;
+  }
+
+  @Test
+  @DisplayName("리뷰별 댓글 수를 기간별로 집계")
+  void findCommentCountsByPeriod_ShouldReturnCountMapWithinPeriod() {
+    createOtherReviews();
+    ReflectionTestUtils.setField(review4, "isDeleted", false);
+
+    Comment c1 = Comment.create(user, review, "<UNK>1");
+    Comment c2 = Comment.create(user, review2, "<UNK>2");
+    Comment c3 = Comment.create(user2, review2, "<UNK>3");
+    Comment c4 = Comment.create(user, review3, "<UNK>4");
+    Comment c5 = Comment.create(user, review4, "<UNK>5");
+    Comment c6 = Comment.create(user2, review4, "<UNK>6");
+    em.persist(c1);
+    em.persist(c2);
+    em.persist(c3);
+    em.persist(c4);
+    em.persist(c5);
+    em.persist(c6);
+
+    updateCommentCreatedAt(day, c1.getId());
+    updateCommentCreatedAt(week, c2.getId());
+    updateCommentCreatedAt(week, c3.getId());
+    updateCommentCreatedAt(month, c4.getId());
+    updateCommentCreatedAt(allTime, c5.getId());
+    updateCommentCreatedAt(allTime, c6.getId());
+    em.flush();
+    em.clear();
+
+    Map<UUID, Long> dayRes = reviewRepositoryCustom.findCommentCountsByPeriod(end.minusDays(1),
+        end);
+    Map<UUID, Long> weekRes = reviewRepositoryCustom.findCommentCountsByPeriod(end.minusWeeks(1),
+        end);
+    Map<UUID, Long> monthRes = reviewRepositoryCustom.findCommentCountsByPeriod(end.minusMonths(1),
+        end);
+    Map<UUID, Long> allRes = reviewRepositoryCustom.findCommentCountsByPeriod(null, null);
+
+    assertThat(dayRes).hasSize(1);
+    assertThat(dayRes.get(review.getId())).isEqualTo(1L);
+    assertThat(weekRes).hasSize(2);
+    assertThat(weekRes.get(review2.getId())).isEqualTo(2L);
+    assertThat(monthRes).hasSize(3);
+    assertThat(monthRes.get(review3.getId())).isEqualTo(1L);
+    assertThat(allRes).hasSize(4);
+    assertThat(allRes.get(review4.getId())).isEqualTo(2L);
+  }
+
+  @Test
+  @DisplayName("해당 기간의 랭킹리뷰 조회")
+  void findCommentCountsByPeriod_ShouldReturnRankingReviewWithinPeriod() {
+    createOtherReviews();
+
+    RankingReview ranking1 = RankingReview.create(review, 9.0, Period.DAILY);
+    RankingReview ranking2 = RankingReview.create(review2, 7.5, Period.DAILY);
+    RankingReview ranking3 = RankingReview.create(review3, 8.2, Period.DAILY);
+    RankingReview ranking4 = RankingReview.create(review4, 10.0, Period.WEEKLY);
+
+    em.persist(ranking1);
+    em.persist(ranking2);
+    em.persist(ranking3);
+    em.persist(ranking4);
+    em.flush();
+    em.clear();
+
+    RankingReviewRequest request = new RankingReviewRequest();
+    request.setLimit(2);
+
+    List<RankingReview> res = reviewRepositoryCustom.findRankingReviewsByPeriod(request, 1);
+
+    assertThat(res).hasSize(2);
+    assertThat(res.get(0).getScore()).isEqualTo(9.0);
+    assertThat(res.get(1).getScore()).isEqualTo(8.2);
+
+    // fetchJoin 검증
+    for (RankingReview rr : res) {
+      assertThat(rr.getReview().getUser().getEmail()).isNotNull();
+      assertThat(rr.getReview().getBook().getTitle()).isNotNull();
+    }
+  }
+
+  @Test
+  @DisplayName("해당 기간의 모든 랭킹리뷰 조회")
+  void countRakingReviewByPeriod_ShouldReturnCountWithinPeriod() {
+    createOtherReviews();
+
+    RankingReview ranking1 = RankingReview.create(review, 9.0, Period.DAILY);
+    RankingReview ranking2 = RankingReview.create(review2, 7.5, Period.DAILY);
+    RankingReview ranking3 = RankingReview.create(review3, 8.2, Period.DAILY);
+    RankingReview ranking4 = RankingReview.create(review4, 10.0, Period.WEEKLY);
+
+    em.persist(ranking1);
+    em.persist(ranking2);
+    em.persist(ranking3);
+    em.persist(ranking4);
+    em.flush();
+    em.clear();
+
+    long res = reviewRepositoryCustom.countRakingReviewByPeriod(Period.DAILY);
+
+    assertThat(res).isEqualTo(3);
+  }
+
+  void createOtherReviews() {
+    user2 = User.create("test2@gmail.com", "test2", "test1234!");
+    user3 = User.create("test3@gmail.com", "test3", "test1234!");
+    user4 = User.create("test4@gmail.com", "test4", "test1234!");
+    book2 = Book.create("book", "book", "book", LocalDate.of(2020, 1, 15)).build();
+    em.persist(user2);
+    em.persist(user3);
+    em.persist(user4);
+    em.persist(book2);
+
+    review2 = Review.create(book, user2, "리뷰2", rating);
+    review3 = Review.create(book2, user3, "리뷰3", rating);
+    review4 = Review.create(book, user4, "리뷰 테스트4", rating);
+    review4.delete();
+
+    em.persist(review2);
+    em.persist(review3);
+    em.persist(review4);
+    em.flush();
+  }
+
+  void updateReviewLikeCreatedAt(LocalDateTime updatedAt, UUID reviewLikeId) {
+    em.createQuery("UPDATE ReviewLike rl SET rl.createdAt = :createdAt WHERE rl.id = :id")
+        .setParameter("createdAt", updatedAt)
+        .setParameter("id", reviewLikeId)
+        .executeUpdate();
+  }
+
+  void updateCommentCreatedAt(LocalDateTime updatedAt, UUID commentId) {
+    em.createQuery("UPDATE Comment c SET c.createdAt = :createdAt WHERE c.id = :id")
+        .setParameter("createdAt", updatedAt)
+        .setParameter("id", commentId)
+        .executeUpdate();
+  }
+}


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?
Review, ReviewLike, Comment, RankingReview 등 리뷰 관련 엔티티들의 Repository 메서드를 구현하고, 이들의 동작을 검증하는 단위 테스트를 추가하였습니다.
특히 커서 기반 리뷰 조회, 기간별 좋아요/댓글 수 집계, 인기 리뷰 랭킹 조회 등의 핵심 기능들을 검증합니다.

왜 이 작업이 필요한가?
Repository 계층은 전체 기능의 데이터 기반을 책임지는 만큼, 쿼리 정확성과 조건 처리에 대한 보장이 필수입니다.
테스트 코드를 통해 예상한 조건과 집계가 정확하게 적용되는지를 확인함으로써, 기능 신뢰도를 높이고 회귀 방지를 도모합니다.

🔍 주요 변경 사항 (What was changed)
✅ ReviewRepositoryImpl
- where.and(review.user.isDeleted.eq(false)); 처럼 isDeleted가 false인 행만 조회하도록 조건 추가.

✅ Repository 테스트 클래스
ReviewAndReviewLikeRepositoryTest
ReviewRepository#findByIdWithUserAndBook
→ Fetch Join을 통해 유저, 도서 정보를 함께 조회하는지 검증

ReviewLikeRepository#countByReviewId
→ 특정 리뷰에 대한 좋아요 수 정확히 반환되는지 검증

ReviewLikeRepository#existsByUserIdAndReviewId
→ 사용자가 리뷰에 좋아요를 눌렀는지 여부를 정확히 판별

ReviewRepositoryImplTest
findAll()
→ 조건(keyword, isDeleted, limit, 정렬)에 따른 리뷰 목록이 정확히 조회되는지 확인 → limit + 1` 개수로 다음 페이지 판단 가능 여부 검증

countByCondition()
→ 동일 조건 기준 리뷰 총 개수가 정확히 계산되는지 검증

findLikeCountsByPeriod()
→ 일간, 주간, 월간, 전체 기간으로 나눠 리뷰별 좋아요 수가 정확히 집계되는지 확인

findCommentCountsByPeriod()
→ 동일한 방식으로 리뷰별 댓글 수 집계 검증

findRankingReviewsByPeriod()
→ RankingReview를 점수 기준으로 정렬하여 조회할 수 있고, Fetch Join으로 연관 데이터가 함께 로딩되는지 확인

countRakingReviewByPeriod()
→ 주어진 기간에 해당하는 랭킹 리뷰 개수를 정확히 반환하는지 검증

🧩 설계 및 구현 고려사항 (Design decisions)
엔티티 상태 조작
테스트 신뢰성을 확보하기 위해 ReflectionTestUtils를 통해 isDeleted, id, createdAt 등을 직접 설정

쿼리 검증의 정확성 확보
JPQL을 직접 실행하여 createdAt 타임스탬프를 수정함으로써 기간별 집계 로직의 정확성을 현실적으로 테스트

제한 수(limit) 및 커서 처리 검증
커서 기반 페이지네이션의 핵심인 limit + 1 로직이 의도대로 작동하는지, 다음 페이지 여부 판단이 정확한지 확인

Fetch Join 동작 보장
단건 조회 및 랭킹 리뷰 조회에서 연관된 유저/도서 정보가 Lazy 로딩이 아닌 즉시 로딩(Fetch Join)으로 처리되는지 검증

도메인 조건과 예외 상태 고려
삭제된 리뷰(isDeleted = true)는 제외되며, 키워드 일치 조건은 유저 닉네임, 도서 제목, 리뷰 내용 등에 적용됨

close #74 
