### PR TITLE
[이종원 | 0608]  OCR 기반 ISBN 추출 기능 추가 · 파라미터 명칭 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ dependencies {
     // JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    //Zxing
+    implementation 'com.google.zxing:core:3.5.1'
+    implementation 'com.google.zxing:javase:3.5.1'
+
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/controller/BookController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/controller/BookController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,6 +44,12 @@ public class BookController implements BookApi {
     BookDto bookDto = bookService.create(request, file);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(bookDto);
+  }
+
+  @PostMapping(value = "/isbn/ocr",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<String> extractIsbn(@RequestParam("image")MultipartFile image) {
+    String barcode = bookService.extractIsbn(image);
+    return ResponseEntity.ok(barcode);
   }
 
   @PatchMapping(value = "/{bookId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BookService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/service/BookService.java
@@ -8,9 +8,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface BookService {
 
-  BookDto create(BookCreateRequest request, MultipartFile file);
+  BookDto create(BookCreateRequest request, MultipartFile image);
 
-  BookDto update(UUID id, BookUpdateRequest request, MultipartFile file);
+  String extractIsbn(MultipartFile image);
+
+  BookDto update(UUID id, BookUpdateRequest request, MultipartFile image);
 
   BookDto findById(UUID id);
 


### PR DESCRIPTION
## 📕 PR 요약: OCR 기반 ISBN 추출 기능 추가 · 파라미터 명칭 리팩터링

이번 Pull Request는 **도서 표지 이미지에서 ISBN을 추출하는 OCR 기능**을 도입하고, 코드 일관성을 높이기 위한 리팩터링을 포함합니다.

---

### 🔍 신규 기능: 이미지(OCR) 기반 ISBN 추출
* **`BookController`**
  * `/isbn/ocr` 엔드포인트(POST) 추가  
    - `MultipartFile`(이미지)을 받아 ZXing으로 바코드를 해석하고 ISBN 문자열을 반환
* **`BasicBookService`**
  * `extractIsbn(MultipartFile image)` 구현  
    - ZXing 라이브러리로 바코드 디코딩  
    - 잘못된 이미지·지원되지 않는 바코드 형식 예외 처리 포함

---

### 🧹 코드 리팩터링: 파라미터 명칭 정리
* `MultipartFile file` → **`MultipartFile image`**  
  - `BookService` 인터페이스, 구현체(`BasicBookService`), 그리고 모든 호출부에서 동일하게 변경  
  - 가독성을 높여 의도를 명확히 함
  - 🔗 예시 변경: [[1]](diffhunk://#diff-2a031fb36eff37dc07f6a0bd12923a607a4a38a6247ec8bd4500999f6fa5b5b7L11-R15) [[2]](diffhunk://#diff-e40c6852e44898af0a46424d28bc5465a31efd9d0b95ad8d612ae5cfb2ba8998L27-R37)

---

### 📦 의존성 추가
* `BasicBookService`에서 **ZXing** 라이브러리 클래스 import  
  - 바코드(ISBN) 디코딩을 위해 필요

---
