### PR TITLE
[한성태 | 0609] MCD를 이용한 로그 관리 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/config/MDCLoggingInterceptor.java
+++ b/src/main/java/com/sprint/deokhugamteam7/config/MDCLoggingInterceptor.java
@@ -19,22 +19,18 @@ public class MDCLoggingInterceptor extends OncePerRequestFilter {
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
     try {
-      // 세션에서 사용자 ID 가져오기
+      // 사용자 ID 설정
       Object userId = request.getSession().getAttribute("userId");
+      String requestId = userId != null ? userId.toString() : "non-member";
+      MDC.put("requestId", requestId);
+      response.setHeader(HEADER, requestId);
 
-      if (userId != null) {
-        response.setHeader(HEADER, userId.toString());
-        MDC.put("userId", userId.toString());
-      } else {
-        // 비로그인 사용자 처리
-        response.setHeader(HEADER, "non-member");
-        MDC.put("userId", "non-member");
+      // 클라이언트 IP 설정
+      String requestIp = request.getHeader("X-Forwarded-For");
+      if (requestIp == null || requestIp.isBlank()) {
+        requestIp = request.getRemoteAddr();
       }
-
-      String requestIp = request.getRequestURI();
-
-      //품질 관리 합시다.
-      MDC.put("ip", requestIp);
+      MDC.put("requestIp", requestIp);
 
       filterChain.doFilter(request, response);
     } finally {


### PR DESCRIPTION
## 🚀 PR 제목

요청 로그 추적을 위한 MDC 필터 추가 및 사용자 ID/IP 기반 로깅 구현

---

## 📌 개요 (What & Why)

- **무엇을 구현했는가?**  
  요청 단위의 로깅 정확도를 높이기 위해 `MDCLoggingInterceptor` 필터를 도입했습니다.  
  해당 필터는 각 요청마다 사용자 ID와 클라이언트 IP를 SLF4J MDC(Mapped Diagnostic Context)에 저장하고, 응답 헤더에도 사용자 ID를 추가로 기록합니다.

- **왜 이 작업이 필요한가?**  
  로그에서 요청별 사용자와 IP를 식별할 수 있도록 구성함으로써, 운영 환경에서 문제 추적과 디버깅의 효율성을 높이기 위함입니다.  
  특히 인증 여부와 상관없이 요청자를 판별하고, 사용자 행동 흐름을 로그로 재구성할 수 있도록 설계되었습니다.  
  또한, 로드 밸런서나 프록시 환경에서도 원래 클라이언트 IP(`X-Forwarded-For`)를 정확히 추적할 수 있도록 반영하였습니다.

---

## 🔍 주요 변경 사항 (What was changed)

- `MDCLoggingInterceptor` 클래스 추가
  - `OncePerRequestFilter`를 상속받아 전역 필터로 설정
  - 세션에서 사용자 ID를 추출하여 `MDC["requestId"]`에 저장
  - 응답 헤더 `"Deokhugam-Request-User-ID"`에 사용자 ID 설정
  - 클라이언트 IP를 `X-Forwarded-For` 우선으로 읽고, 없을 경우 `request.getRemoteAddr()`로 대체
  - `MDC["requestIp"]`에 IP 저장
  - 요청 처리 완료 후 `MDC.clear()`를 통해 컨텍스트 초기화

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **클라이언트 식별 정보 로깅**  
  사용자 ID가 없는 비로그인 사용자도 `non-member`로 명시적으로 로그에 기록되도록 처리하여, 모든 요청의 식별 가능성을 확보했습니다. 이는 운영 환경에서 로그인/비로그인 유저 행위 분석에 유리합니다.

- **IP 추적 정확성 확보**  
  프록시 환경을 고려해 `X-Forwarded-For` 헤더의 첫 번째 값을 IP로 사용하도록 하여 원본 요청자의 IP를 최대한 정확하게 식별할 수 있게 했습니다. 프록시 미적용 환경에서는 `request.getRemoteAddr()`로 fallback 처리됩니다.

- **MDC 사용 목적과 위치**  
  SLF4J MDC는 요청 처리 중 로그에 공통 식별 정보를 자동으로 삽입하는 데 적합하며, 필터에서 초기 설정하고 반드시 `finally` 블록에서 `clear()`하여 스레드 풀 간의 컨텍스트 누수를 방지하였습니다.

---
