### PR TITLE
[최규원 | 0609] 유저별 활동 데이터 수집 방법 수정

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/repository/custom/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/repository/custom/UserQueryRepositoryImpl.java
@@ -97,11 +97,10 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
         ));
 
     Map<UUID, Long> likeCountMap = queryFactory
-        .select(review.user.id, reviewLike.count())
+        .select(reviewLike.user.id, reviewLike.count())
         .from(reviewLike)
-        .join(reviewLike.review, review)
         .where(reviewLike.createdAt.between(start, end.minusNanos(1)))
-        .groupBy(review.user.id)
+        .groupBy(reviewLike.user.id)
         .fetch()
         .stream()
         .collect(Collectors.toMap(
@@ -110,11 +109,10 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
         ));
 
     Map<UUID, Long> commentCountMap = queryFactory
-        .select(review.user.id, comment.count())
+        .select(comment.user.id, comment.count())
         .from(comment)
-        .join(comment.review, review)
         .where(comment.createdAt.between(start, end.minusNanos(1)))
-        .groupBy(review.user.id)
+        .groupBy(comment.user.id)
         .fetch()
         .stream()
         .collect(Collectors.toMap(


### PR DESCRIPTION
# 🚀 PR 제목

fix: 유저별 활동 데이터 수집 기준 오류 수정 (댓글/좋아요 본인 기준으로 수정)

---

## 📌 개요 (What & Why)

### 무엇을 수정했는가?

- 사용자 활동 점수 계산 로직에서 **댓글 수, 좋아요 수 집계 기준이 잘못 설정되어 있던 문제**를 수정했습니다.
- 기존에는 **내 리뷰에 달린 좋아요/댓글 수를 기준**으로 집계하고 있었으나,  
  **"내가 좋아요를 누르거나 내가 단 댓글" 수로 집계해야 한다는 요구사항에 부합하지 않았습니다.  

### 왜 이 작업이 필요한가?

- 활동 점수 기반 파워 유저 선정 기능의 신뢰성과 정확도를 확보하기 위함입니다.
- 집계 기준 오류로 인해 실제 유저의 활동량과 무관한 점수가 반영되는 문제를 방지하고자 했습니다.

---

## 🔍 주요 변경 사항 (What was changed)

- `UserQueryRepositoryImpl#collectUserActivityScores` 메서드 수정:
  - 좋아요 수: `review.user.id` → ✅ `reviewLike.user.id` 기준으로 수정
  - 댓글 수: `review.user.id` → ✅ `comment.user.id` 기준으로 수정
- 쿼리 내부의 groupBy 대상도 **리뷰 작성자 → 활동 주체(좋아요/댓글 작성자)**로 일관되게 수정

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **비즈니스 정책 정합성 유지**
  - “본인이 수행한 활동”만이 점수에 반영되도록 기준을 명확히 조정하였고,  
    리뷰 점수는 여전히 본인이 작성한 리뷰 기준으로 유지됩니다.

- **기존 기능 호환성**
  - 다른 서비스 로직이나 통계 기능과의 충돌 없이 안전하게 반영되도록 변경 범위를 최소화함