### PR TITLE
[김태우 | 0610] 댓글 테스트, 데이터 삽입 기능 구현

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/comment/controller/CommentController.java
@@ -88,12 +88,4 @@ public class CommentController {
 
 		return ResponseEntity.ok(commentDto);
 	}
-
-	// TODO 전체 댓글 수를 따로 카운트 해주는게 더 효율이 좋을 것 같음. review_comment_count table 같은거 만들어서 ./
-	@GetMapping("/api/comments/reviews/{reviewId}")
-	public Long count(
-		@PathVariable("reviewId") Long reviewId
-	) {
-		return commentService.count(reviewId);
-	}
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/comment/service/CommentService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/comment/service/CommentService.java
@@ -96,9 +96,9 @@ public class CommentService {
 		String content = commentUpdateRequest.content();
 		comment.update(content);
 
-    if (content == null || content.isBlank()) { // isBlank() 사용!
-      throw new IllegalArgumentException("댓글은 공백일 수 없습니다.");
-    }
+		if (content == null || content.isBlank()) { // isBlank() 사용!
+			throw new IllegalArgumentException("댓글은 공백일 수 없습니다.");
+		}
 
 		return CommentDto.from(comment);
 	}
@@ -189,16 +189,10 @@ public class CommentService {
 	@Transactional(readOnly = true)
 	public CommentDto getComment(UUID commentId) {
 //		log.info("[CommentService] getComment request: commentId={}", commentId);
-
 		Comment comment = commentRepository.findById(commentId).orElseThrow(
 			() -> new EntityNotFoundException("comment not found")
 		);
 
 		return CommentDto.from(comment);
-	}
-
-	public Long count(Long reviewId) {
-		// TODO: review_comment_count 이런 테이블 하나 만들어서 댓글 수 반환하기
-		return 0L;
 	}
 }

--- a/src/test/java/com/sprint/deokhugamteam7/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/comment/controller/CommentControllerTest.java
@@ -1,5 +1,148 @@
 package com.sprint.deokhugamteam7.domain.comment.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sprint.deokhugamteam7.domain.comment.dto.CommentDto;
+import com.sprint.deokhugamteam7.domain.comment.dto.request.CommentCreateRequest;
+import com.sprint.deokhugamteam7.domain.comment.dto.request.CommentUpdateRequest;
+import com.sprint.deokhugamteam7.domain.comment.dto.response.CursorPageResponseCommentDto;
+import com.sprint.deokhugamteam7.domain.comment.service.CommentService;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
 class CommentControllerTest {
 
+	private MockMvc mockMvc;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Mock
+	private CommentService commentService;
+
+	@InjectMocks
+	private CommentController commentController;
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(commentController).build();
+	}
+
+	@Test
+	@DisplayName("POST /api/comments - 댓글 생성 API 테스트")
+	void createTest() throws Exception {
+		// given
+		UUID reviewId = UUID.randomUUID();
+		UUID userId = UUID.randomUUID();
+		String content = "테스트 댓글 내용";
+		CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, content);
+		CommentDto responseDto = new CommentDto(UUID.randomUUID(), reviewId, userId, "유저닉네임",
+			content, LocalDateTime.now(), LocalDateTime.now());
+
+		given(commentService.create(any(CommentCreateRequest.class))).willReturn(responseDto);
+
+		// when & then
+		mockMvc.perform(post("/api/comments")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.id").value(responseDto.id().toString()));
+	}
+
+	@Test
+	@DisplayName("PATCH /api/comments/{commentId} - 댓글 수정 API 테스트")
+	void updateTest() throws Exception {
+		// given
+		UUID commentId = UUID.randomUUID();
+		UUID userId = UUID.randomUUID();
+		String newContent = "수정된 댓글 내용";
+		CommentUpdateRequest request = new CommentUpdateRequest(newContent);
+		CommentDto responseDto = new CommentDto(commentId, UUID.randomUUID(), userId, "유저닉네임",
+			newContent, LocalDateTime.now(), LocalDateTime.now());
+
+		given(commentService.update(eq(commentId), eq(userId),
+			any(CommentUpdateRequest.class))).willReturn(responseDto);
+
+		// when
+		ResultActions actions = mockMvc.perform(patch("/api/comments/{commentId}", commentId)
+			.header("Deokhugam-Request-User-ID", userId.toString())
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)));
+
+		// then
+		actions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(commentId.toString()))
+			.andExpect(jsonPath("$.content").value(newContent))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("DELETE /api/comments/{commentId} - 댓글 논리적 삭제 API 테스트")
+	void deleteTest() throws Exception {
+		// given
+		UUID commentId = UUID.randomUUID();
+		UUID userId = UUID.randomUUID();
+
+		// when
+		ResultActions actions = mockMvc.perform(delete("/api/comments/{commentId}", commentId)
+			.header("Deokhugam-Request-User-ID", userId.toString()));
+
+		// then
+		actions
+			.andExpect(status().isNoContent())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("GET /api/comments - 댓글 목록 조회 API 테스트")
+	void readTest() throws Exception {
+		// given
+		UUID reviewId = UUID.randomUUID();
+		CommentDto comment1 = new CommentDto(UUID.randomUUID(), reviewId, UUID.randomUUID(),
+			"user1", "content1", LocalDateTime.now(), LocalDateTime.now());
+		CommentDto comment2 = new CommentDto(UUID.randomUUID(), reviewId, UUID.randomUUID(),
+			"user2", "content2", LocalDateTime.now(), LocalDateTime.now());
+		CursorPageResponseCommentDto response = new CursorPageResponseCommentDto(
+			List.of(comment1, comment2), comment2.id(), comment2.createdAt(), 2, 10L, true);
+
+		given(commentService.getCommentList(eq(reviewId), any(String.class), any(), any(),
+			any(int.class))).willReturn(response);
+
+		// when
+		ResultActions actions = mockMvc.perform(get("/api/comments")
+			.param("reviewId", reviewId.toString())
+			.param("limit", "10"));
+
+		// then
+		actions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content.length()").value(2))
+			.andExpect(jsonPath("$.content[0].content").value("content1"))
+			.andExpect(jsonPath("$.hasNext").value(true))
+			.andDo(print());
+	}
 }

--- a/src/test/java/com/sprint/deokhugamteam7/domain/comment/data/DataInitializer.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/comment/data/DataInitializer.java
@@ -1,10 +1,23 @@
 package com.sprint.deokhugamteam7.domain.comment.data;
 
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.book.repository.BookRepository;
+import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.review.repository.ReviewRepository;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest
@@ -16,35 +29,69 @@ public class DataInitializer {
 	@Autowired
 	TransactionTemplate transactionTemplate;
 
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	ReviewRepository reviewRepository;
+
+	@Autowired
+	BookRepository bookRepository; // Review 생성 시 Book이 필요하다면
+
+	private User testUser;
+	private Review testReview;
+
 	CountDownLatch latch = new CountDownLatch(EXECUTE_COUNT);
 
-	static final int BULK_INSERT_SIZE = 200;
-	static final int EXECUTE_COUNT = 600;
+	static final int BULK_INSERT_SIZE = 600;
+	static final int EXECUTE_COUNT = 200;
 
-//	@Test
-//	void initialize() throws InterruptedException {
-//		ExecutorService executorService = Executors.newFixedThreadPool(10);
-//
-//		for (int cnt_i = 0; cnt_i < EXECUTE_COUNT; cnt_i++) {
-//			executorService.submit(() -> {
-//				insert();
-//				latch.countDown();
-//				System.out.println("latch.getCountDown(): " + latch.getCount());
-//			});
-//		}
-//
-//		latch.await();
-//		executorService.shutdown();
-//	}
-//
-//	void insert() {
-//		transactionTemplate.executeWithoutResult(status -> {
-//			for (int cnt_i = 0; cnt_i < BULK_INSERT_SIZE; cnt_i++) {
-//				Comment comment = Comment.create(
-//
-//				);
-//				entityManager.persist(comment);
-//			}
-//		});
-//	}
+	@BeforeEach
+	void setupTestData() {
+		testUser = User.create("email", "nickname", "password");
+		userRepository.saveAndFlush(testUser);
+
+		Book testBook = Book.create("title", "author", "publisher", LocalDate.now())
+			.title("title")
+			.author("author")
+			.description("description")
+			.publisher("publisher")
+			.publishedDate(LocalDate.now())
+			.isbn("isbn")
+			.thumbnailUrl("thumbnailUrl")
+			.build();
+		bookRepository.saveAndFlush(testBook);
+
+		testReview = Review.create(testBook, testUser, "content", 1);
+		reviewRepository.saveAndFlush(testReview);
+	}
+
+	// 데이터 삽입할때 application-test.yml 파일에 show-sql 설정을 잠깐 false 로 설정해야합니다.
+	@Test
+	@Commit
+	void initialize() throws InterruptedException {
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		for (int cnt_i = 0; cnt_i < EXECUTE_COUNT; cnt_i++) {
+			executorService.submit(() -> {
+				insert();
+				latch.countDown();
+				System.out.println("latch.getCount(): " + latch.getCount());
+			});
+		}
+		latch.await();
+		executorService.shutdown();
+	}
+
+	void insert() {
+		transactionTemplate.executeWithoutResult(status -> {
+			for (int cnt_i = 0; cnt_i < BULK_INSERT_SIZE; cnt_i++) {
+				Comment comment = Comment.create(
+					testUser,
+					testReview,
+					String.format("%d번째 test 댓글 입니다.", cnt_i)
+				);
+				entityManager.persist(comment);
+			}
+		});
+	}
 }

--- a/src/test/java/com/sprint/deokhugamteam7/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,107 @@
+package com.sprint.deokhugamteam7.domain.comment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sprint.deokhugamteam7.config.QueryDslConfig;
+import com.sprint.deokhugamteam7.config.TestAuditingConfig;
+import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({QueryDslConfig.class, TestAuditingConfig.class})
+class CommentRepositoryTest {
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Autowired
+	private TestEntityManager testEntityManager;
+
+	private User testUser;
+	private Review testReview;
+
+	@BeforeEach
+	void setUp() {
+		testUser = User.create("test@user.com", "testuser", "password");
+		testEntityManager.persist(testUser);
+
+		Book testBook = Book.create("Test Book", "Test Author", "Test Publisher", LocalDate.now())
+			.description("이것은 테스트용 책입니다.") // Builder를 통해 다른 필드들도 설정 가능
+			.isbn("978-1234567890")
+			.thumbnailUrl("http://example.com/image.jpg")
+			.build();
+		testEntityManager.persist(testBook);
+
+		testReview = Review.create(testBook, testUser, "Test Review", 5);
+		testEntityManager.persist(testReview);
+
+		for (int i = 0; i < 10; i++) {
+			Comment comment = Comment.create(testUser, testReview, "Test Comment " + i);
+			testEntityManager.persist(comment);
+		}
+		testEntityManager.flush();
+		testEntityManager.clear();
+	}
+
+	@Test
+	@DisplayName("첫 페이지 조회 (findFirstPage) 테스트")
+	void findFirstPageTest() {
+		// given
+		int limit = 5;
+
+		// when
+		List<Comment> firstPage = commentRepository.findFirstPage(testReview.getId(), "DESC",
+			limit);
+
+		// then
+		assertThat(firstPage).hasSize(limit);
+	}
+
+	@Test
+	@DisplayName("다음 페이지 조회 (findNextPage) 테스트")
+	void findNextPage_Success() {
+		// given
+		int firstPageLimit = 3;
+		List<Comment> firstPage = commentRepository.findFirstPage(testReview.getId(), "DESC",
+			firstPageLimit);
+		Comment lastCommentOfFirstPage = firstPage.get(firstPage.size() - 1);
+		UUID cursorId = lastCommentOfFirstPage.getId();
+		LocalDateTime createdAt = lastCommentOfFirstPage.getCreatedAt();
+
+		int nextPageLimit = 3;
+
+		// when
+		List<Comment> nextPage = commentRepository.findNextPage(testReview.getId(), "DESC",
+			cursorId, createdAt, nextPageLimit);
+
+		// then
+		assertThat(nextPage).hasSize(nextPageLimit);
+		assertThat(nextPage.get(0).getCreatedAt()).isBeforeOrEqualTo(createdAt);
+	}
+
+	@Test
+	@DisplayName("리뷰 ID로 댓글 수 조회 (countByReviewId) 테스트")
+	void countByReviewId_Success() {
+		// given
+		// @BeforeEach에서 총 10개의 댓글이 생성됨
+
+		// when
+		Long totalCount = commentRepository.countByReviewId(testReview.getId());
+
+		// then
+		assertThat(totalCount).isEqualTo(10L);
+	}
+}

--- a/src/test/java/com/sprint/deokhugamteam7/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/comment/service/CommentServiceTest.java
@@ -1,5 +1,176 @@
 package com.sprint.deokhugamteam7.domain.comment.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sprint.deokhugamteam7.domain.comment.dto.CommentDto;
+import com.sprint.deokhugamteam7.domain.comment.dto.request.CommentCreateRequest;
+import com.sprint.deokhugamteam7.domain.comment.dto.request.CommentUpdateRequest;
+import com.sprint.deokhugamteam7.domain.comment.entity.Comment;
+import com.sprint.deokhugamteam7.domain.comment.repository.CommentRepository;
+import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
+import com.sprint.deokhugamteam7.domain.notification.repository.NotificationRepository;
+import com.sprint.deokhugamteam7.domain.review.entity.Review;
+import com.sprint.deokhugamteam7.domain.review.repository.ReviewRepository;
+import com.sprint.deokhugamteam7.domain.user.entity.User;
+import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 class CommentServiceTest {
 
+	@Mock
+	private CommentRepository commentRepository;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private ReviewRepository reviewRepository;
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@InjectMocks
+	private CommentService commentService;
+
+	@Test
+	@DisplayName("create 성공 케이스")
+	void createTest() {
+		// given
+		UUID userId = UUID.randomUUID();
+		UUID reviewId = UUID.randomUUID();
+		String content = "new content";
+		CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, content);
+
+		User mockUser = Mockito.mock(User.class);
+		Review mockReview = Mockito.mock(Review.class);
+		User mockReviewOwner = Mockito.mock(User.class);
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+		when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(mockReview));
+		when(mockUser.isDeleted()).thenReturn(false);
+		when(mockReview.getIsDeleted()).thenReturn(false);
+		when(mockReview.getUser()).thenReturn(mockReviewOwner);
+
+		when(commentRepository.save(any(Comment.class))).thenAnswer(
+			invocation -> invocation.getArgument(0));
+		when(notificationRepository.save(any(Notification.class))).thenAnswer(
+			invocation -> invocation.getArgument(0));
+
+		// when
+		CommentDto result = commentService.create(request);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.content()).isEqualTo(content);
+
+		verify(commentRepository).save(any(Comment.class));
+		verify(notificationRepository).save(any(Notification.class));
+	}
+
+	@Test
+	@DisplayName("생성 실패 - user id 검증 실패")
+	void createTest2() {
+		// given
+		UUID userId = UUID.randomUUID();
+		UUID reviewId = UUID.randomUUID();
+		CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, "내용");
+
+		when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> commentService.create(request))
+			.isInstanceOf(EntityNotFoundException.class)
+			.hasMessage("user not found");
+	}
+
+	@Test
+	@DisplayName("update 성공 케이스")
+	void updateTest() {
+		// given
+		UUID commentId = UUID.randomUUID();
+		UUID correctUserId = UUID.randomUUID();
+		String newContent = "수정된 내용입니다.";
+		CommentUpdateRequest request = new CommentUpdateRequest(newContent);
+
+		User mockUser = Mockito.mock(User.class);
+		Review mockReview = Mockito.mock(Review.class);
+		Comment mockComment = Mockito.mock(Comment.class);
+
+		when(commentRepository.findById(commentId)).thenReturn(Optional.of(mockComment));
+		when(mockComment.getUser()).thenReturn(mockUser);
+		when(mockUser.getId()).thenReturn(correctUserId);
+		when(mockComment.getReview()).thenReturn(mockReview);
+		when(mockComment.getId()).thenReturn(commentId);
+		when(mockReview.getId()).thenReturn(UUID.randomUUID());
+		when(mockUser.getNickname()).thenReturn("테스트유저");
+		when(mockComment.getCreatedAt()).thenReturn(LocalDateTime.now().minusDays(1));
+		when(mockComment.getContent()).thenReturn(newContent);
+		when(mockComment.getUpdatedAt()).thenReturn(LocalDateTime.now());
+
+		// when
+		CommentDto resultDto = commentService.update(commentId, correctUserId, request);
+
+		// then
+		verify(mockComment).update(newContent);
+
+		assertThat(resultDto).isNotNull();
+		assertThat(resultDto.id()).isEqualTo(commentId);
+		assertThat(resultDto.content()).isEqualTo(newContent);
+	}
+
+	@Test
+	@DisplayName("update 실패 케이스 - 수정 권한이 없을 때")
+	void updateTest2() {
+		// given
+		UUID commentId = UUID.randomUUID();
+		UUID correctUserId = UUID.randomUUID();
+		UUID wrongUserId = UUID.randomUUID();
+		CommentUpdateRequest request = new CommentUpdateRequest("수정 시도");
+
+		User mockUser = Mockito.mock(User.class);
+		Comment mockComment = Mockito.mock(Comment.class);
+
+		when(commentRepository.findById(commentId)).thenReturn(Optional.of(mockComment));
+		when(mockComment.getUser()).thenReturn(mockUser);
+		when(mockUser.getId()).thenReturn(correctUserId);
+
+		// when & then
+		assertThatThrownBy(() -> commentService.update(commentId, wrongUserId, request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("해당 댓글을 수정할 권한이 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패 케이스 - 내용이 공백일 때")
+	void update_comment_fail_content_is_blank() {
+		// given
+		UUID commentId = UUID.randomUUID();
+		UUID userId = UUID.randomUUID();
+		String blankContent = "   ";
+		CommentUpdateRequest request = new CommentUpdateRequest(blankContent);
+
+		User mockUser = Mockito.mock(User.class);
+		Comment mockComment = Mockito.mock(Comment.class);
+
+		when(commentRepository.findById(commentId)).thenReturn(Optional.of(mockComment));
+		when(mockComment.getUser()).thenReturn(mockUser);
+		when(mockUser.getId()).thenReturn(userId);
+
+		// when & then
+		assertThatThrownBy(() -> commentService.update(commentId, userId, request))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("댓글은 공백일 수 없습니다.");
+	}
 }


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?

댓글(Comment) 도메인의 핵심 CRUD 및 커서 기반 페이지네이션 기능에 대한 계층별 테스트 코드를 작성했습니다.
대량의 테스트 데이터를 효율적으로 생성하기 위한 병렬 데이터 초기화(DataInitializer) 클래스를 구현하고 문제점을 해결했습니다.
파일 첨부 기능을 지원하기 위해 컨트롤러 API의 요청 처리 방식을 수정했습니다.
왜 이 작업이 필요한가?

각 계층(Controller, Service, Repository)을 독립적으로 또 통합적으로 검증하여 코드의 안정성과 신뢰도를 확보합니다.
단위 테스트, 데이터 계층 테스트, API 계층 테스트를 통해 각 부분의 역할과 책임을 명확히 하고, 향후 기능 변경 및 리팩토링 시 발생할 수 있는 **문제를 미리 방지(회귀 테스트)**하기 위함입니다.
🔍 주요 구현 내용 (What was implemented)
✅ Repository 통합 테스트 (@DataJpaTest)

@DataJpaTest를 사용하여 데이터 접근 계층을 고립시켜 테스트하는 환경을 구축했습니다.
CommentRepository에 직접 작성한 네이티브 SQL 쿼리들(커서 기반 페이지네이션을 위한 findFirstPage, findNextPage 등)이 실제 데이터베이스(H2)와 정확하게 상호작용하는지 검증했습니다.
TestEntityManager를 사용하여 각 테스트 전에 필요한 User, Review, Comment 등의 데이터를 준비하고, 테스트 간 독립성을 보장했습니다.
테스트 컨텍스트 로딩 시 발생했던 JPAQueryFactory 및 JPA Auditing 관련 빈(Bean) 생성 문제를 @Import 및 @EnableJpaAuditing 분리를 통해 해결했습니다.
✅ Service 단위 테스트 (Mockito)

@ExtendWith(MockitoExtension.class)와 @Mock, @InjectMocks를 사용하여 CommentService를 테스트했습니다.
UserRepository, ReviewRepository 등 CommentService가 의존하는 모든 외부 컴포넌트를 가짜(Mock) 객체로 대체했습니다.
when(...).thenReturn(...) 구문을 통해 이 가짜 객체들의 행동을 시나리오에 맞게 제어함으로써, 오직 CommentService 내부의 비즈니스 로직만을 순수하게 검증했습니다.
✅ Controller 파일 첨부 기능 구현

게시글/댓글 수정 시 파일(들)을 함께 받을 수 있도록 컨트롤러 메서드의 파라미터를 수정했습니다.
multipart/form-data 요청을 처리하기 위해, 기존 @RequestBody 대신 @RequestPart 어노테이션을 사용하여 JSON 데이터와 파일 데이터를 함께 받는 방법을 적용했습니다.
이로 인해 API를 호출하는 클라이언트(테스트 코드, 프론트엔드 등)의 요청 방식도 변경되어야 함을 확인했습니다.
✅ 대량 데이터 초기화 (DataInitializer)

ExecutorService (스레드 풀)와 CountDownLatch를 사용하여 수만 건 이상의 데이터를 병렬로 빠르게 삽입하는 테스트를 구현했습니다.
각 스레드에서 실행되는 DB 저장 작업을 TransactionTemplate으로 묶어 데이터 정합성을 보장했습니다.
@SpringBootTest의 기본 트랜잭션 롤백 정책 문제를 파악하고, @Commit 어노테이션과 ddl-auto: create 설정을 통해 테스트 후 데이터가 실제로 DB에 남도록 하는 방법을 적용했습니다.
🧩 설계 및 구현 고려사항 (Design decisions)
테스트 환경의 분리:

실제 애플리케이션 설정과 테스트 설정을 분리하기 위해 src/test/resources/application.yml에 테스트 전용 데이터베이스 및 프로퍼티를 설정하는 방식을 채택했습니다. 이를 통해 어떤 환경에서도 일관되게 동작하는 안정적인 테스트 기반을 마련했습니다.
계층별 테스트 전략:

단위 테스트 (Service): 외부 의존성을 모두 Mocking하여 로직의 정확성을 빠르고 가볍게 검증합니다.
통합 테스트 (Repository): @DataJpaTest를 통해 실제 DB와의 연동 및 SQL 쿼리의 정확성을 검증합니다.
API 테스트 (Controller): @WebMvcTest와 MockMvc를 사용하여 HTTP 요청/응답, 파라미터 바인딩 등 웹 계층의 동작을 검증합니다.
이처럼 각 계층의 책임에 맞는 테스트를 분리하여 작성함으로써, 테스트의 속도와 신뢰도를 모두 확보하는 전략을 사용했습니다.
비동기/병렬 작업의 동기화:

대량 데이터 생성기(DataInitializer)에서 ExecutorService를 사용한 병렬 처리의 모든 작업이 완료될 때까지 CountDownLatch를 사용하여 메인 스레드가 안전하게 기다리도록 구현하여, 정확한 테스트 종료 시점과 실행 시간 측정을 보장했습니다.