### PR TITLE
[한성태 | 0610] 알람 jococo 테스트 커버리지 향상 진행

### DIFF
--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/unit/controller/NotificationControllerTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/unit/controller/NotificationControllerTest.java
@@ -1,6 +1,7 @@
 package com.sprint.deokhugamteam7.domain.notification.unit.controller;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -10,6 +11,7 @@ import com.sprint.deokhugamteam7.domain.notification.controller.NotificationCont
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
 import com.sprint.deokhugamteam7.domain.notification.service.NotificationService;
 import com.sprint.deokhugamteam7.domain.user.service.UserService;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,74 +30,88 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(controllers = NotificationController.class)
 class NotificationControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired
+  MockMvc mockMvc;
 
-    @MockitoBean
-    private NotificationService notificationService;
+  @MockitoBean
+  private NotificationService notificationService;
 
-    @MockitoBean
-    private UserService userService;
-    @Autowired
-    private ObjectMapper objectMapper;
+  @MockitoBean
+  private UserService userService;
 
-    private UUID userId;
-    private UUID notificationId;
-    private NotificationUpdateRequest notificationUpdateRequest;
+  @Autowired
+  private ObjectMapper objectMapper;
 
-    @BeforeEach
-    void setUp() {
-        userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-        notificationId = UUID.fromString("22222222-2222-2222-2222-222222222222");
-        notificationUpdateRequest = new NotificationUpdateRequest(true);
-    }
+  private UUID userId;
+  private UUID notificationId;
+  private NotificationUpdateRequest notificationUpdateRequest;
 
-    @Test
-    @DisplayName("알람 수정 시 NotificationId 타입 변환 에러 - 400")
-    void notificationUpdateTypeMatchError() throws Exception {
-        mockMvc.perform(patch("/api/notifications/{notificationId}", "error")
-                .header("Deokhugam-Request-User-ID", userId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(notificationUpdateRequest))
-                .with(csrf())
-            )
-            .andExpect(status().isBadRequest())
-            .andDo(print());
-    }
+  @BeforeEach
+  void setUp() {
+    userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    notificationId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    notificationUpdateRequest = new NotificationUpdateRequest(true);
+  }
 
-    @Test
-    @DisplayName("알람 수정 시 Deokhugam-Request-User-ID 누락 에러 - 400")
-    void notificationUpdateRequestParameterError() throws Exception {
-        mockMvc.perform(patch("/api/notifications/{notificationId}", notificationId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(notificationUpdateRequest))
-                .with(csrf())
-            )
-            .andExpect(status().isBadRequest())
-            .andDo(print());
-    }
+  @Test
+  @DisplayName("알람 수정 시 NotificationId 타입 변환 에러 - 400")
+  void notificationUpdateTypeMatchError() throws Exception {
+    mockMvc.perform(patch("/api/notifications/{notificationId}", "error")
+        .header("Deokhugam-Request-User-ID", userId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(notificationUpdateRequest))
+        .with(csrf())
+      )
+      .andExpect(status().isBadRequest())
+      .andDo(print());
+  }
 
-    @Test
-    @DisplayName("알림 수정 시 NotificationUpdateRequest 누락 에러 - 400")
-    void NotificationUpdateRequest() throws Exception {
-        mockMvc.perform(patch("/api/notifications/{notificationId}", notificationId)
-                .header("Deokhugam-Request-User-ID", userId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(csrf())
-            )
-            .andExpect(status().isBadRequest())
-            .andDo(print());
-    }
+  @Test
+  @DisplayName("알람 수정 시 Deokhugam-Request-User-ID 누락 에러 - 400")
+  void notificationUpdateRequestParameterError() throws Exception {
+    mockMvc.perform(patch("/api/notifications/{notificationId}", notificationId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(notificationUpdateRequest))
+        .with(csrf())
+      )
+      .andExpect(status().isBadRequest())
+      .andDo(print());
+  }
 
-    @Test
-    @DisplayName("알림 목록 수정 시 Deokhugam-Request-User-ID 누락 에러 - 400")
-    void notificationUpdateRequestParameter() throws Exception {
-        mockMvc.perform(patch("/api/notifications/read-all")
-            .contentType(MediaType.APPLICATION_JSON)
-            .with(csrf())
-          )
-          .andExpect(status().isBadRequest())
-          .andDo(print());
-    }
+  @Test
+  @DisplayName("알림 수정 시 NotificationUpdateRequest 누락 에러 - 400")
+  void NotificationUpdateRequest() throws Exception {
+    mockMvc.perform(patch("/api/notifications/{notificationId}", notificationId)
+        .header("Deokhugam-Request-User-ID", userId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(csrf())
+      )
+      .andExpect(status().isBadRequest())
+      .andDo(print());
+  }
+
+  @Test
+  @DisplayName("알림 목록 수정 시 Deokhugam-Request-User-ID 누락 에러 - 400")
+  void notificationUpdateRequestParameter() throws Exception {
+    mockMvc.perform(patch("/api/notifications/read-all")
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(csrf())
+      )
+      .andExpect(status().isBadRequest())
+      .andDo(print());
+  }
+
+  @Test
+  @DisplayName("알람 목록 조회 시 after 누락 에러(cursor 존재) - 400")
+  void notificationFindAllCursorAssertError() throws Exception {
+    mockMvc.perform(get("/api/notifications")
+        .contentType(MediaType.APPLICATION_JSON)
+        .param("userId", UUID.randomUUID().toString())
+        .param("cursor", LocalDateTime.now().toString())
+        .param("after", "")
+        .with(csrf()))
+      .andExpect(status().isBadRequest())
+      .andDo(print());
+  }
 
 }

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/unit/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/unit/repository/NotificationRepositoryTest.java
@@ -93,7 +93,7 @@ class NotificationRepositoryTest {
     }
 
     @Test
-    void 커서_기반_목록_조회_desc() {
+    void 커서_기반_목록_조회_정렬_desc() {
         NotificationCursorRequest request = new NotificationCursorRequest(
             user.getId(),
             "DESC",
@@ -107,6 +107,95 @@ class NotificationRepositoryTest {
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.hasNext()).isTrue();
         assertThat(result.getContent().get(0).content()).startsWith("알림 내용");
+    }
+
+    @Test
+    void 커서_기반_목록_조회_정렬_asc() {
+        NotificationCursorRequest request = new NotificationCursorRequest(
+          user.getId(),
+          "ASC",
+          null,
+          null,
+          2
+        );
+
+        Slice<NotificationDto> result = notificationRepository.findAllByCursor(request);
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.getContent().get(0).content()).startsWith("알림 내용");
+    }
+
+    @Test
+    void 커서_기반_목록_조회_with_cursor_정렬_DESC() {
+        LocalDateTime after = LocalDateTime.now();
+        String cursor = LocalDateTime.now().toString();
+
+        NotificationCursorRequest request = new NotificationCursorRequest(
+          user.getId(),
+          "DESC",
+          cursor,
+          after,
+          3
+        );
+
+        Slice<NotificationDto> result = notificationRepository.findAllByCursor(request);
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    void 커서_기반_목록_조회_with_cursor_정렬_ASC() {
+        LocalDateTime after = LocalDateTime.now();
+        String cursor = LocalDateTime.now().toString();
+
+        NotificationCursorRequest request = new NotificationCursorRequest(
+          user.getId(),
+          "ASC",
+          cursor,
+          after,
+          3
+        );
+
+        Slice<NotificationDto> result = notificationRepository.findAllByCursor(request);
+        assertThat(result.getContent()).hasSize(0);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    void 커서_기반_목록_조회_cursor_존재_after_null_커서_동작_x() {
+        String cursor = LocalDateTime.now().plusWeeks(2).toString();
+        LocalDateTime after = null;
+
+        NotificationCursorRequest request = new NotificationCursorRequest(
+          user.getId(),
+          "DESC",
+          cursor,
+          after,
+          3
+        );
+
+        Slice<NotificationDto> result = notificationRepository.findAllByCursor(request);
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    void 커서_기반_목록_조회_cursor_empty_after_존재_커서_동작_x() {
+        String cursor = "";
+        LocalDateTime after = LocalDateTime.now().plusWeeks(2);
+
+        NotificationCursorRequest request = new NotificationCursorRequest(
+          user.getId(),
+          "DESC",
+          cursor,
+          after,
+          3
+        );
+
+        Slice<NotificationDto> result = notificationRepository.findAllByCursor(request);
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.hasNext()).isFalse();
     }
 
 }

--- a/src/test/java/com/sprint/deokhugamteam7/domain/notification/unit/service/impl/NotificationServiceImplTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/notification/unit/service/impl/NotificationServiceImplTest.java
@@ -5,8 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.sprint.deokhugamteam7.domain.book.entity.Book;
+import com.sprint.deokhugamteam7.domain.notification.dto.NotificationCursorRequest;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationDto;
 import com.sprint.deokhugamteam7.domain.notification.dto.NotificationUpdateRequest;
 import com.sprint.deokhugamteam7.domain.notification.entity.Notification;
@@ -17,7 +20,9 @@ import com.sprint.deokhugamteam7.domain.user.entity.User;
 import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
 import com.sprint.deokhugamteam7.exception.ErrorCode;
 import com.sprint.deokhugamteam7.exception.notification.NotificationException;
+import com.sprint.deokhugamteam7.exception.user.UserException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,78 +36,137 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceImplTest {
 
-    @InjectMocks
-    private NotificationServiceImpl notificationService;
+  @InjectMocks
+  private NotificationServiceImpl notificationService;
 
-    @Mock
-    private NotificationRepository notificationRepository;
+  @Mock
+  private NotificationRepository notificationRepository;
 
-    @Mock
-    private UserRepository userRepository;
+  @Mock
+  private UserRepository userRepository;
 
-    private final UUID NOTIFICATION_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
-    private final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
-    private final UUID OTHER_USER_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+  private final UUID NOTIFICATION_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+  private final UUID OTHER_USER_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+  private final UUID not_found_user_id = UUID.fromString("99999999-9999-9999-9999-999999999999");
 
-    private User user;
-    private User otherUser;
-    private Review review;
-    private Notification notification;
-    private NotificationUpdateRequest request;
+  private User user;
+  private User otherUser;
+  private Review review;
+  private Notification notification;
+  private NotificationUpdateRequest request;
 
-    @BeforeEach
-    void setup() {
-        user = User.create("test1", "test1", "test1");
-        setPrivateField(user, "id", USER_ID);
+  @BeforeEach
+  void setup() {
+    user = User.create("test1", "test1", "test1");
+    setPrivateField(user, "id", USER_ID);
 
-        otherUser = User.create("test2", "test2", "test2");
-        setPrivateField(otherUser, "id", OTHER_USER_ID);
+    otherUser = User.create("test2", "test2", "test2");
+    setPrivateField(otherUser, "id", OTHER_USER_ID);
 
-        Book book = Book.create("testBook", "testBook", "testBook", LocalDate.now()).build();
+    Book book = Book.create("testBook", "testBook", "testBook", LocalDate.now()).build();
 
-        review = Review.create(book, user, "책의 리뷰입니다.", 3);
-        setPrivateField(review, "user", user);
+    review = Review.create(book, user, "책의 리뷰입니다.", 3);
+    setPrivateField(review, "user", user);
 
-        notification = Notification.create(user, review, "테스트 알림");
-        setPrivateField(notification, "id", NOTIFICATION_ID);
+    notification = Notification.create(user, review, "테스트 알림");
+    setPrivateField(notification, "id", NOTIFICATION_ID);
 
-        request = new NotificationUpdateRequest(true);
+    request = new NotificationUpdateRequest(true);
+  }
+
+  @Test
+  @DisplayName("알림 수정 성공 - confirmed 수정 확인")
+  void 알림_수정_성공() {
+    // given
+    given(notificationRepository.findById(any())).willReturn(Optional.of(notification));
+    given(userRepository.findById(any())).willReturn(Optional.of(user));
+
+    // when
+    NotificationDto result = notificationService.update(NOTIFICATION_ID, USER_ID, request);
+
+    // then
+    assertThat(result.confirmed()).isTrue();
+  }
+
+  @Test
+  @DisplayName("알림 수정 실패 - NOTIFICATION_NOT_FOUND")
+  void notificationNotFoundById() {
+    // given
+    given(notificationRepository.findById(notification.getId())).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+      () -> notificationService.update(notification.getId(), user.getId(), request))
+      .isInstanceOf(NotificationException.class)
+      .hasMessageContaining(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("알림 수정 실패 - USER_NOT_FOUND")
+  void updateUserNotFoundById() {
+    // given
+    given(notificationRepository.findById(any())).willReturn(Optional.of(notification));
+    given(userRepository.findById(not_found_user_id)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+      () -> notificationService.update(notification.getId(), not_found_user_id, request))
+      .isInstanceOf(UserException.class)
+      .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("알림 목록 수정 실패 - USER_NOT_FOUND")
+  void updateAllUserNotFoundById() {
+    // given
+    given(userRepository.findById(not_found_user_id)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+      () -> notificationService.updateAll(not_found_user_id))
+      .isInstanceOf(UserException.class)
+      .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("알림 목록 조회 실패 - USER_NOT_FOUND")
+  void findAllByUserIdNotFound() {
+    // given
+    NotificationCursorRequest request = new NotificationCursorRequest(
+      not_found_user_id,
+      null,
+      null,
+      null,
+      null
+    );
+    given(userRepository.findById(not_found_user_id)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(
+      () -> notificationService.findAll(request))
+      .isInstanceOf(UserException.class)
+      .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("알림 삭제 성공")
+  void notification_delete_byCreatedAt() {
+    // when
+    notificationService.softDeleteNotificationsOlderThanAWeek();
+
+    // then
+    verify(notificationRepository, times(1)).softDeleteOldNotifications(any());
+  }
+
+
+  private void setPrivateField(Object target, String fieldName, Object value) {
+    try {
+      var field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (Exception e) {
+      throw new RuntimeException("리플렉션으로 필드 설정 실패: " + fieldName, e);
     }
-
-    @Test
-    @DisplayName("알림 수정 성공 - confirmed 수정 확인")
-    void 알림_수정_성공() {
-        // given
-        given(notificationRepository.findById(any())).willReturn(Optional.of(notification));
-        given(userRepository.findById(any())).willReturn(Optional.of(user));
-
-        // when
-        NotificationDto result = notificationService.update(NOTIFICATION_ID, USER_ID, request);
-
-        // then
-        assertThat(result.confirmed()).isTrue();
-    }
-
-    @Test
-    @DisplayName(("알림 수정 실패 - NOTIFICATION_NOT_FOUND"))
-    void notificationNotFoundById() {
-        // given
-        given(notificationRepository.findById(notification.getId())).willReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> notificationService.update(notification.getId(), user.getId(), request))
-            .isInstanceOf(NotificationException.class)
-            .hasMessageContaining(ErrorCode.NOTIFICATION_NOT_FOUND.getMessage());
-    }
-
-
-    private void setPrivateField(Object target, String fieldName, Object value) {
-        try {
-            var field = target.getClass().getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(target, value);
-        } catch (Exception e) {
-            throw new RuntimeException("리플렉션으로 필드 설정 실패: " + fieldName, e);
-        }
-    }
+  }
 }


### PR DESCRIPTION
## 🚀 PR 제목  
테스트 커버리지 80% 이상 달성을 위한 Notification 기능 테스트 케이스 보완  

---

## 📌 개요 (What & Why)

### 무엇을 구현했는가?
- `Notification` 기능 전반에 대한 테스트 코드를 보완하여, 누락된 예외 상황 및 커서 기반 조회 케이스를 추가했습니다.  
- 특히 잘못된 요청 파라미터, 요청 본문 누락, ID 타입 불일치 등 사용자 요청 흐름에서 발생할 수 있는 다양한 에러 상황을 테스트로 명시했습니다.

### 왜 이 작업이 필요한가?
- 테스트 커버리지 기준을 **80% 이상**으로 설정하고, jacoco 기준 미달 영역을 확인해 이를 보완하기 위한 작업입니다.  
- 단순 커버리지 확보를 넘어, 실제 운영 중 발생 가능한 요청 흐름을 검증하고, **예외 처리의 안정성**을 테스트하기 위해 수행했습니다.

---

## 🔍 주요 변경 사항 (What was changed)

### 예외 상황 테스트 추가
- 잘못된 `notificationId` 타입 전달 시 `400 Bad Request` 발생 확인
- 요청 헤더(`Deokhugam-Request-User-ID`) 누락 시 에러 확인
- `NotificationUpdateRequest` 본문 누락 케이스 검증

### 목록 수정 및 조회 관련 테스트 보완
- `read-all` 엔드포인트에 대한 헤더 누락 케이스 추가
- 커서 기반 조회 시 `cursor` 존재 및 `after` 누락 케이스에 대한 테스트

### 정상 흐름 테스트 확장
- 커서 기반 정렬(ASC/DESC) 각각에 대한 정상 조회 테스트
- `cursor/after` 조합에 따른 동작 유무 확인 테스트
- 삭제 기준일(`createdAt`) 기반 알림 소프트 삭제 테스트

### 서비스 단위 테스트 추가
- 알림 단건 수정 성공 및 예외 케이스 (`NOTIFICATION_NOT_FOUND`, `USER_NOT_FOUND`)
- 알림 전체 확인 처리 예외 케이스
- 알림 전체 조회 예외 케이스

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

- **실제 사용자 요청 흐름을 기반으로 테스트 시나리오 구성**  
  컨트롤러 레벨의 테스트에서는 CSRF, 헤더, 파라미터 누락 등 현실적인 요청 실패 흐름을 중심으로 구성하였으며,  
  이를 통해 **잘못된 요청에 대한 서버의 응답 처리 일관성**을 보장합니다.

- **커서 기반 페이지네이션 동작 조건 검증**  
  커서 기반 조회 기능에서는 `cursor`와 `after`의 동시 사용 여부에 따라 동작 여부가 달라지므로,  
  이를 명시적으로 확인하는 테스트 케이스를 추가하여 **동작 조건을 명확히 정의**했습니다.

- **서비스 단 검증을 통해 핵심 비즈니스 로직 보완**  
  단건/전체 알림 확인 기능에서 사용자 존재 여부 및 알림 존재 여부에 따라 **적절한 예외가 발생하는지 명확히 검증**했습니다.
