### PR TITLE
[최규원 | 0611] 파워 유저 중복 저장 문제 수정

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/batch/step/UserScoreWriter.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/batch/step/UserScoreWriter.java
@@ -19,8 +19,14 @@ public class UserScoreWriter implements ItemWriter<UserScore> {
   @Override
   public void write(Chunk<? extends UserScore> chunk) throws Exception {
     for (UserScore score : chunk) {
+      UUID id = score.getId();
+
+      if (id == null) {
+        id = UUID.randomUUID();
+      }
+
       userScoreRepository.upsertUserScore(
-          UUID.randomUUID(),
+          id,
           score.getUser().getId(),
           score.getPeriod().name(),
           score.getScore(),

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/batch/step/UserScoreWriter.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/batch/step/UserScoreWriter.java
@@ -23,6 +23,7 @@ public class UserScoreWriter implements ItemWriter<UserScore> {
 
       if (id == null) {
         id = UUID.randomUUID();
+        score.setId(id);
       }
 
       userScoreRepository.upsertUserScore(


### PR DESCRIPTION
## 🚀 PR 제목  
UserScoreWriter 중복 저장 방지를 위한 ID 처리 로직 수정

---

## 📌 개요 (What & Why)

- **무엇을 수정했는가?**  
  `UserScoreWriter` 클래스에서 `UUID.randomUUID()`를 무조건 사용해 새로운 ID로 insert되는 문제를 수정했습니다.

- **왜 수정했는가?**  
  `user_score` 테이블에 `(user_id, period, date)`가 동일한 데이터가 중복으로 저장되는 문제가 발생하고 있었으며, 이는 upsert 대상 row의 `id`를 매번 다르게 생성하고 있었기 때문입니다.  
  PostgreSQL의 `ON CONFLICT (user_id, period, date)` 절이 제대로 동작하려면 ID가 고정되어야 하며, 중복 시에는 기존 row를 갱신해야 합니다.

---

## ✅ 변경 사항 (What was changed)

- `UserScoreWriter`에서 `UUID.randomUUID()` 대신 `UserScore.getId()`를 사용하도록 변경
- `score.getId()`가 `null`인 경우에만 새로운 UUID 생성하여 초기 insert 대응
- 결과적으로 `user_score` 테이블에 중복 row가 저장되지 않고 기존 row가 갱신되도록 개선

---

## 🔍 사용자 흐름 (User Flow)

1. 활동 점수 배치 실행 (`PowerUserScoreSchedule`)
2. 각 기간(DAILY, WEEKLY 등)에 대한 점수를 계산하여 `UserScore` 생성
3. 기존에 동일한 `(user_id, period, date)` 데이터가 있을 경우 → 해당 row 업데이트
4. 없을 경우 → 새로 생성 (ID는 새로 생성됨)

---

## 🧪 테스트 및 확인 사항

- [x] 배치 실행 후 `user_score` 테이블에 중복 row가 생기지 않는지 확인
- [x] 기존 데이터가 잘 업데이트되는지 확인
- [x] 신규 유저 점수는 정상 insert되는지 확인

---

## ⚠️ 참고 사항

- `UserScore` 생성 시점(`UserScore.create()`)에서 ID를 미리 세팅하는 방식도 대안이 될 수 있습니다.
- `UserScoreRepository.upsertUserScore()` 쿼리에는 `ON CONFLICT` 절이 있으므로, `(user_id, period, date)` 제약이 잘 걸려 있어야 합니다.
