### PR TITLE
[최규원 | 0611] 사용자 접근 필터 추가 및 동점자 랭킹 산정 방식 개선

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/config/SecurityConfig.java
+++ b/src/main/java/com/sprint/deokhugamteam7/config/SecurityConfig.java
@@ -8,17 +8,21 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
 
+  private final UserAccessFilter userAccessFilter;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     return http
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+        .addFilterBefore(userAccessFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }
 

--- a/src/main/java/com/sprint/deokhugamteam7/config/UserAccessFilter.java
+++ b/src/main/java/com/sprint/deokhugamteam7/config/UserAccessFilter.java
@@ -1,0 +1,71 @@
+package com.sprint.deokhugamteam7.config;
+
+import com.sprint.deokhugamteam7.domain.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class UserAccessFilter extends OncePerRequestFilter {
+
+  private static final String HEADER_NAME = "Deokhugam-Request-User-ID";
+
+  private final UserRepository userRepository;
+
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+  private static final List<String> WHITE_LIST = List.of(
+      "/", "/index.html", "/favicon.ico",
+      "/static/**", "/assets/**", "/css/**", "/js/**", "/images/**",
+      "/api/users", "/api/users/login", "/api/users/power",
+      "/api/reviews/popular", "/api/books/popular"
+  );
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+    return WHITE_LIST.stream().anyMatch(pattern -> pathMatcher.match(pattern, uri));
+  }
+
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String headerUserId = request.getHeader(HEADER_NAME);
+    Object sessionUserId = request.getSession().getAttribute("userId");
+
+    if (headerUserId == null || headerUserId.isBlank() || sessionUserId == null) {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "사용자 인증 정보가 없습니다.");
+      return;
+    }
+
+    try {
+      UUID headerId = UUID.fromString(headerUserId);
+      UUID sessionId = UUID.fromString(sessionUserId.toString());
+
+      if (!headerId.equals(sessionId)) {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "세션 정보와 헤더 정보가 일치하지 않습니다.");
+        return;
+      }
+
+      if (!userRepository.existsById(headerId)) {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "존재하지 않는 사용자입니다.");
+        return;
+      }
+
+      filterChain.doFilter(request, response);
+    } catch (IllegalArgumentException e) {
+      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "잘못된 사용자 ID 형식입니다.");
+    }
+  }
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/batch/step/UserScoreWriter.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/batch/step/UserScoreWriter.java
@@ -23,6 +23,7 @@ public class UserScoreWriter implements ItemWriter<UserScore> {
 
       if (id == null) {
         id = UUID.randomUUID();
+        score.updateId(id); // JPA의 save가 아니라 네이티브 쿼리(upsertUserScore)를 사용할 경우 @GeneratedValue가 적용되지 않아서 수동으로 설정함
       }
 
       userScoreRepository.upsertUserScore(

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/entity/UserScore.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/entity/UserScore.java
@@ -108,4 +108,8 @@ public class UserScore {
     this.rank = rank;
   }
 
+  public void updateId(UUID id) {
+    this.id = id;
+  }
+
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/service/PowerUserServiceImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/service/PowerUserServiceImpl.java
@@ -111,10 +111,23 @@ public class PowerUserServiceImpl implements PowerUserService {
     if (scores.isEmpty()) return;
 
     long rank = 1;
-    for (UserScore score : scores) {
-      score.updateRank(rank++);
+    double prevScore = scores.get(0).getScore(); // 첫 번째 유저가 기준값
+    scores.get(0).updateRank(rank); // 첫 번째 유저 랭킹 1등
+
+    for (int i = 1; i < scores.size(); i++) { // 두 번째 유저부터 반복
+      UserScore current = scores.get(i); // 현재 유저 점수 객체 가져옴
+      double currentScore = current.getScore(); // 현재 유저 점수
+
+      if (Double.compare(currentScore, prevScore) != 0) { // 기준값과 점수가 다르면 순위 증가
+        rank++;
+      }
+
+      current.updateRank(rank);
+      prevScore = currentScore; // 기준값을 현재 유저 점수로 갱신
     }
+
     userScoreRepository.saveAll(scores);
   }
+
 
 }


### PR DESCRIPTION
## PR 제목
feat: 사용자 접근 필터 추가 및 동점자 랭킹 산정 방식 개선 (1→1→2→3)

---

## 작업 내용 요약
- 사용자 접근 필터(UserAccessFilter) 추가 및 화이트리스트 경로 적용
- UserScoreWriter에서 id가 null일 때 UUID 생성하여 upsert 처리
- 점수가 동일할 시 랭킹 산정 방식 변경 (1→1→2→3)
- 관련 SecurityConfig, Entity, Service 등 코드 수정

---

## 주요 변경 파일
- src/main/java/com/sprint/deokhugamteam7/config/SecurityConfig.java
- src/main/java/com/sprint/deokhugamteam7/config/UserAccessFilter.java
- src/main/java/com/sprint/deokhugamteam7/domain/user/batch/step/UserScoreWriter.java
- src/main/java/com/sprint/deokhugamteam7/domain/user/entity/UserScore.java
- src/main/java/com/sprint/deokhugamteam7/domain/user/service/PowerUserServiceImpl.java

---

## 상세 변경 내역
### 사용자 접근 필터 및 화이트리스트
- UserAccessFilter 추가: 헤더·세션 일치, 사용자 존재여부 체크
- SecurityConfig에서 해당 필터 chain에 등록 및 화이트리스트 경로 적용

### UserScoreWriter 개선
- id가 null일 경우 UUID 직접 생성 및 할당 (업서트 시 대응)

### 동점자 랭킹 처리 개선
- PowerUserServiceImpl에서 동점자 동일 랭크 처리, 다음 랭크는 동점자 수와 관계없이 바로 증가 (1→1→2→3)

---

## 테스트 및 검증
- 신규 접근 필터 정상 동작 확인
- 랭킹 산정 로직 변경 후 정상적으로 1→1→2→3 형태로 랭킹 부여되는지 확인

---

### 리뷰어에게 바라는 점
- 보안/접근제어 방식 검토
- 랭킹 산정 로직에 대한 추가 개선점 피드백 환영

---