### PR TITLE
[선혜린 | 0612] ReviewActivity 조회 성능 개선 및 댓글 기준 컬럼을 updatedAt으로 수정

### DIFF
--- a/src/test/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImplTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/review/repository/ReviewRepositoryImplTest.java
@@ -174,12 +174,12 @@ public class ReviewRepositoryImplTest {
     updateReviewLikeCreatedAt(allTime, like5.getId());
     updateReviewLikeCreatedAt(allTime, like6.getId());
 
-    updateCommentCreatedAt(day, c1.getId());
-    updateCommentCreatedAt(week, c2.getId());
-    updateCommentCreatedAt(week, c3.getId());
-    updateCommentCreatedAt(month, c4.getId());
-    updateCommentCreatedAt(allTime, c5.getId());
-    updateCommentCreatedAt(allTime, c6.getId());
+    updateCommentUpdatedAt(day, c1.getId());
+    updateCommentUpdatedAt(week, c2.getId());
+    updateCommentUpdatedAt(week, c3.getId());
+    updateCommentUpdatedAt(month, c4.getId());
+    updateCommentUpdatedAt(allTime, c5.getId());
+    updateCommentUpdatedAt(allTime, c6.getId());
 
     em.flush();
     em.clear();
@@ -371,9 +371,9 @@ public class ReviewRepositoryImplTest {
         .executeUpdate();
   }
 
-  void updateCommentCreatedAt(LocalDateTime updatedAt, UUID commentId) {
-    em.createQuery("UPDATE Comment c SET c.createdAt = :createdAt WHERE c.id = :id")
-        .setParameter("createdAt", updatedAt)
+  void updateCommentUpdatedAt(LocalDateTime updatedAt, UUID commentId) {
+    em.createQuery("UPDATE Comment c SET c.updatedAt = :updatedAt WHERE c.id = :id")
+        .setParameter("updatedAt", updatedAt)
         .setParameter("id", commentId)
         .executeUpdate();
   }


### PR DESCRIPTION
📌 개요 (What & Why)
무엇을 구현했는가?
인기 리뷰 점수 산정에 사용되는 findReviewActivitySummary()의 쿼리 병목을 개선하였으며, 댓글 수 계산 기준을 createdAt에서 updatedAt으로 변경하여 실질적인 활동 반영도를 높였습니다.

왜 이 작업이 필요한가?
기존에는 좋아요 수, 댓글 수, 리뷰 목록을 각각 쿼리로 조회하여 병합하는 구조였고, 이로 인해 데이터 양이 많을 경우 성능 저하 및 병목 가능성이 있었습니다. 또한, 댓글 수 산정 기준이 생성일(createdAt) 기준이어서 수정 활동이 반영되지 않는다는 문제가 있었습니다. 이를 해결하기 위해 단일 쿼리로 구조를 최적화하고, 댓글 활동 기준을 수정일(updatedAt)로 변경했습니다.

🔍 주요 변경 사항 (What was changed)
ReviewRepositoryCustom.findReviewActivitySummary()를 다음과 같이 단일 쿼리로 리팩토링:

리뷰 ID별 좋아요 수, 댓글 수를 한 번에 조인 및 그룹화하여 조회

댓글 수 기준을 updatedAt으로 변경

```
.leftJoin(c).on(
    c.review.id.eq(review.id)
        .and(c.isDeleted.eq(false))
        .and(c.user.isDeleted.eq(false))
        .and(start != null && end != null ? c.updatedAt.between(start, end) : null)
)
```
기존의 3회 조회 → 메모리 병합 구조를 제거하여 병목 현상 예방

기존 테스트 코드 updateCommentCreatedAt() → updateCommentUpdatedAt()으로 수정

테스트 대상 기준 컬럼 변경을 반영

🧩 설계 및 구현 고려사항 (Design decisions)
쿼리 단일화로 병목 해소
다중 쿼리를 통한 수집 → 메모리 병합 구조는 데이터가 많아질수록 병목과 GC 부하가 발생할 수 있음. 이를 QDSL 조인과 group by로 통합 처리하여 서버 측 부하 감소

활동성 정확도 향상
댓글은 작성 시점뿐 아니라 수정 시점에서도 사용자 활동이 발생할 수 있으므로, updatedAt을 기준으로 집계하는 것이 더 정확한 인기 점수 산정 기준이 됨

테스트 코드 일관성 유지
수정된 컬럼 기준을 반영하여 테스트 쿼리(updateCommentUpdatedAt)도 함께 변경, 테스트 정확성 보장