### PR TITLE
task: 로그 파일 S3 업로드 수정 및 동작 확인

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/log/service/LogService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/log/service/LogService.java
@@ -1,8 +1,6 @@
-package com.sprint.deokhugamteam7.domain.log;
+package com.sprint.deokhugamteam7.domain.log.service;
 
 import com.sprint.deokhugamteam7.constant.LogType;
-import com.sprint.deokhugamteam7.exception.DeokhugamException;
-import com.sprint.deokhugamteam7.exception.ErrorCode;
 import java.io.File;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -33,29 +31,25 @@ public class LogService {
   @Scheduled(cron = "0 10 0 * * *")
   public void logUploadToS3() {
 
-    LocalDate yesterday = LocalDate.now().minusDays(1);
-    String dateStr = yesterday.format(FORMATTER);
+    String todayStr = LocalDate.now().format(FORMATTER);
+    String yesterdayStr = LocalDate.now().minusDays(1).format(FORMATTER);
 
-    File myappLog = new File(LogType.MYAPP.getLogDir() + dateStr + LOG_EXTENSION);
-    File errorLog =  new File(LogType.ERROR.getLogDir() + dateStr + TXT_EXTENSION);
+    File myappLog = new File(LogType.MYAPP.getLogDir() + yesterdayStr + LOG_EXTENSION);
+    File errorLog =  new File(LogType.ERROR.getLogDir() + todayStr + TXT_EXTENSION);
 
     uploadIfFileExists(myappLog, myappLog.getName());
     uploadIfFileExists(errorLog, errorLog.getName());
   }
 
   private void uploadIfFileExists(File file, String s3Key) {
-    String s3Url = BASE_DIR + s3Key;
+    String s3path = BASE_DIR + s3Key;
     if (file.exists()) {
-      try {
-        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-          .bucket(bucketName)
-          .key(s3Url)
-          .build();
+      PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+        .bucket(bucketName)
+        .key(s3path)
+        .build();
 
-        s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
-      } catch (Exception e) {
-         throw new DeokhugamException(ErrorCode.INTERNAL_SERVER_ERROR);
-      }
+      s3Client.putObject(putObjectRequest, RequestBody.fromFile(file));
     }
   }
 }


### PR DESCRIPTION
# 🚀 PR 제목  
**S3 로그 업로드 로직 개선 및 날짜 기준 정합성 수정**

---

## 📌 개요 (What & Why)

### 무엇을 구현했는가?
로그 파일을 AWS S3로 업로드하는 스케줄러의 날짜 기준을 수정하고, 에러 로그 파일 처리 방식에 대한 정합성을 개선하였습니다.

### 왜 이 작업이 필요한가?
기존 구현에서는 `myapp.log`와 `error.txt` 로그 모두 전날 기준으로 업로드되도록 처리하고 있었으나, 실제로는 에러 로그 파일(`error-yyyy-MM-dd.txt`)이 현재 날짜 기준으로 기록되므로 업로드 시점의 날짜와 맞지 않는 문제가 있었습니다.  
이로 인해 예상한 로그가 S3에 업로드되지 않는 이슈가 발생할 수 있어 이를 해결하기 위한 작업입니다.

---

## 🔍 주요 변경 사항 (What was changed)

### `LogService#logUploadToS3`
- **기존**: `yesterday` 날짜 기준으로 `myapp.log`, `error.txt` 모두 처리  
- **변경**:  
  - `myapp.log`는 전날(`yesterday`) 기준  
  - `error.txt`는 당일(`today`) 기준으로 파일명 생성 및 업로드 수행

### `uploadIfFileExists` 메서드
- `DeokhugamException` 예외 처리를 제거하고, S3 업로드 실패 시 단순히 예외를 던지도록 변경하여 **코드 간결화**
- 불필요한 `import` 정리 및 파일 경로 변수명을 `s3Key` → `s3path`로 변경하여 **명확성 향상**

---

## 🧩 설계 및 구현 고려사항 (Design decisions)

### 날짜 정합성 유지
`error` 로그는 `logback.xml` 설정상 `"logs/error-${DATE}.txt"` 형식으로, 서비스가 작동 중인 날짜에 생성됩니다.  
따라서 전날 기준으로 파일을 찾으면 업로드가 실패하므로, **`error.txt`는 오늘 날짜 기준으로 처리**하도록 명확히 구분했습니다.

### 예외 처리 전략 단순화
S3 업로드 실패는 **비즈니스 로직상의 오류가 아닌 운영상 이슈**로 간주되므로, 기존의 custom 예외(`DeokhugamException`)로 감싸는 방식 대신 **예외를 그대로 던지도록 리팩터링**하였습니다.  
추후 모니터링 또는 알림 연계를 도입할 경우, 이 부분은 확장 가능합니다.

### 파일 존재 여부 체크 방식 유지
존재하지 않는 로그 파일에 대해 업로드 요청을 보내지 않도록 기존의 `File.exists()` 체크 방식은 그대로 유지하여 **불필요한 네트워크 요청을 방지**했습니다.
