### PR TITLE
[최규원 | 0613] 파워 유저 데일리 오류 수정

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/config/BatchConfig.java
+++ b/src/main/java/com/sprint/deokhugamteam7/config/BatchConfig.java
@@ -27,11 +27,13 @@ public class BatchConfig {
   @Bean
   public Job userScoreJob(
       JobRepository jobRepository,
+      @Qualifier("deleteUserScoreStep") Step deleteUserScoreStep,
       @Qualifier("collectAndSaveUserScoresStep") Step collectAndSaveUserScoresStep,
       @Qualifier("updateUserRankingStep") Step updateUserRankingStep
   ) {
     return new JobBuilder("userScoreJob", jobRepository)
-        .start(collectAndSaveUserScoresStep)
+        .start(deleteUserScoreStep)
+        .next(collectAndSaveUserScoresStep)
         .next(updateUserRankingStep)
         .build();
   }
@@ -60,6 +62,17 @@ public class BatchConfig {
   ) {
     return new StepBuilder("updateUserRankingStep", jobRepository)
         .tasklet(rankUpdateTasklet, transactionManager)
+        .build();
+  }
+
+  @Bean
+  public Step deleteUserScoreStep(
+      JobRepository jobRepository,
+      PlatformTransactionManager transactionManager,
+      Tasklet deleteUserScoreTasklet
+  ) {
+    return new StepBuilder("deleteUserScoreStep", jobRepository)
+        .tasklet(deleteUserScoreTasklet, transactionManager)
         .build();
   }
 

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/batch/tasklet/DeleteUserScoreTasklet.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/batch/tasklet/DeleteUserScoreTasklet.java
@@ -1,0 +1,32 @@
+package com.sprint.deokhugamteam7.domain.user.batch.tasklet;
+
+import com.sprint.deokhugamteam7.constant.Period;
+import com.sprint.deokhugamteam7.domain.user.repository.UserScoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class DeleteUserScoreTasklet implements Tasklet {
+
+  private final UserScoreRepository userScoreRepository;
+
+  @Value("#{jobParameters['period']}")
+  private String periodStr;
+
+  @Override
+  public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+    Period period = Period.valueOf(periodStr.toUpperCase());
+
+    userScoreRepository.deleteByPeriod(period);
+
+    return RepeatStatus.FINISHED;
+  }
+}

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/repository/UserScoreRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/repository/UserScoreRepository.java
@@ -42,4 +42,10 @@ public interface UserScoreRepository extends JpaRepository<UserScore, UUID> {
       @Param("likeCount") long likeCount,
       @Param("commentCount") long commentCount
   );
+
+  @Modifying
+  @Transactional
+  @Query("DELETE FROM UserScore us WHERE us.period = :period")
+  void deleteByPeriod(@Param("period") Period period);
+
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/user/repository/custom/UserQueryRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/user/repository/custom/UserQueryRepositoryImpl.java
@@ -79,8 +79,16 @@ public class UserQueryRepositoryImpl implements UserQueryRepository {
 
   @Override
   public List<UserActivity> collectUserActivityScores(Period period, LocalDate baseDate) {
-    LocalDateTime start = getStartDate(period, baseDate).atStartOfDay();
-    LocalDateTime end = baseDate.plusDays(1).atStartOfDay(); // exclusive
+    LocalDateTime start;
+    LocalDateTime end;
+
+    if (period == Period.DAILY) {
+      end = LocalDateTime.now(); // 현재 시간
+      start = end.minusHours(24); // 24시간 전
+    } else {
+      start = getStartDate(period, baseDate).atStartOfDay();
+      end = baseDate.plusDays(1).atStartOfDay();
+    }
 
     // 유저별 활동 데이터 수집
     Map<UUID, Double> reviewScoreMap = queryFactory


### PR DESCRIPTION
## 🔥 PR 제목

fix: 오류 수정

---

## 📌 변경 사항

- **BatchConfig**: `userScoreJob`에 `deleteUserScoreStep`이 추가되어, 기존 점수 삭제 후 집계 및 랭킹 업데이트가 수행됩니다.
- **DeleteUserScoreTasklet**: 사용자 점수 삭제를 위한 Tasklet 클래스가 신설되었습니다.
- **UserScoreRepository**: `deleteByPeriod` 메서드가 추가되어, 특정 기간의 사용자 점수를 삭제할 수 있습니다.
- **UserQueryRepositoryImpl**: 기간이 `DAILY`인 경우, 활동 데이터 집계의 시작/종료 시간이 24시간 기준으로 변경되어 실시간 집계가 가능합니다.

---

## 🛠️ 관련 이슈

- (선택) 관련된 이슈 번호가 있다면 여기에 연결하세요. 예시: #123

---

## 👀 중점적으로 봐야 할 부분

- 주입되는 period 파라미터의 값이 정상적으로 동작하는지 확인
- `deleteUserScoreStep`이 정상적으로 실행되어 데이터가 삭제되는지 여부
- `collectUserActivityScores`의 기간 계산이 정확하게 작동하는지
- 트랜잭션, 롤백 등 예외 처리에서 데이터 무결성 보장 여부

---

## 🚦 테스트 방법

1. Batch Job 실행 시, 기존 사용자 점수 데이터가 정상적으로 삭제되는지 확인
2. DAILY 집계가 정확히 24시간 기준으로 동작하는지 확인
3. 전체 Batch 프로세스가 정상 완료되는지 확인

---

## 📸 스크린샷(선택)

- (필요시 관련 로그, 에러 메시지, 동작 화면 등 첨부)

---

## 🙏 기타 참고사항

- 코드 리뷰 및 기능 테스트 부탁드립니다.