### PR TITLE
[이종원 | 0614] ISBN 처리 개선 · switch 식 리팩터링 · 테스트 업데이트

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/batch/step/RankingBookProcessor.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/batch/step/RankingBookProcessor.java
@@ -39,7 +39,7 @@ public class RankingBookProcessor implements ItemProcessor<RankingBook,RankingBo
       case DAILY -> now.minusDays(1);
       case WEEKLY -> now.minusWeeks(1);
       case MONTHLY -> now.minusMonths(1);
-      default -> now.minusYears(1);
+      default -> now.minusYears(20);
     };
   }
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/dto/request/BookCreateRequest.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/dto/request/BookCreateRequest.java
@@ -18,5 +18,4 @@ public record BookCreateRequest(
     @Schema(description = "isbn", example = "9788990982575")
     String isbn
 ) {
-
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/dto/response/CursorPageResponseBookDto.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/dto/response/CursorPageResponseBookDto.java
@@ -31,21 +31,13 @@ public record CursorPageResponseBookDto(
     if (hasNext) {
       BookDto last = page.get(page.size() - 1);
 
-      switch (orderBy) {
-        case "publishedDate":
-          nextCursor = last.publishedDate().toString();
-          break;
-        case "rating":
-          nextCursor = String.valueOf(last.rating());
-          break;
-        case "reviewCount":
-          nextCursor = String.valueOf(last.reviewCount());
-          break;
-        case "title":
-        default:
-          nextCursor = last.title();
-          break;
-      }
+      nextCursor = switch (orderBy) {
+        case "publishedDate" -> last.publishedDate().toString();
+        case "rating" -> String.valueOf(last.rating());
+        case "reviewCount" -> String.valueOf(last.reviewCount());
+        default -> last.title();
+      };
+
       nextAfter = last.createdAt();
     }
 

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/repository/BookRepository.java
@@ -11,7 +11,5 @@ public interface BookRepository extends JpaRepository<Book, UUID> {
   @Query("SELECT b FROM Book b JOIN FETCH b.rankingBooks WHERE b.id = :id AND b.isDeleted = false")
   Optional<Book> findByIdAndIsDeletedFalse(UUID id);
 
-  boolean existsByIsbn(String isbn);
-
-  boolean existsByIsbnAndIsDeletedIsFalse(String isbn);
+  Optional<Book> findByIsbn(String isbn);
 }

--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/repository/custom/RankingBookRepositoryImpl.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/repository/custom/RankingBookRepositoryImpl.java
@@ -118,19 +118,13 @@ public class RankingBookRepositoryImpl implements RankingBookRepositoryCustom {
 
   private OrderSpecifier<?> buildOrder(String sortField, String direction) {
     boolean asc = "asc".equalsIgnoreCase(direction);
-    switch (sortField) {
-      case "publishedDate":
-        return asc ? book.publishedDate.asc() : book.publishedDate.desc();
-      case "rating":
-        return asc ? rankingBook.rating.asc() : rankingBook.rating.desc();
-      case "reviewCount":
-        return asc ? rankingBook.reviewCount.asc() : rankingBook.reviewCount.desc();
-      case "score":
-        return asc ? rankingBook.score.asc() : rankingBook.score.desc();
-      case "title":
-      default:
-        return asc ? book.title.asc() : book.title.desc();
-    }
+    return switch (sortField) {
+      case "publishedDate" -> asc ? book.publishedDate.asc() : book.publishedDate.desc();
+      case "rating" -> asc ? rankingBook.rating.asc() : rankingBook.rating.desc();
+      case "reviewCount" -> asc ? rankingBook.reviewCount.asc() : rankingBook.reviewCount.desc();
+      case "score" -> asc ? rankingBook.score.asc() : rankingBook.score.desc();
+      default -> asc ? book.title.asc() : book.title.desc();
+    };
   }
 
   private BooleanExpression buildCursorCondition(String sortField, String direction,

--- a/src/main/java/com/sprint/deokhugamteam7/exception/ErrorCode.java
+++ b/src/main/java/com/sprint/deokhugamteam7/exception/ErrorCode.java
@@ -33,10 +33,7 @@ public enum ErrorCode {
 
   //도서 오류
   BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "?", "도서를 찾을 수 없습니다."),
-  INVALID_BOOK_REGISTER(HttpStatus.CONFLICT,"?","동일한 ISBN 존재합니다."),
-  //TODO 도서 엔티티에 유저 엔티티 연관관계 집어넣는 등의 복잡한 작업 수행해야해서 일단 주석처리
-//  BOOK_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN,"?","해당 도서를 수정할 권한이 없습니다."),
-//  BOOK_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN,"?","해당 도서를 삭제할 권한이 없습니다."),
+  DUPLICATE_ISBN(HttpStatus.CONFLICT,"?","동일한 ISBN 존재합니다."),
 
   //리뷰 오류
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "?", "리뷰를 찾을 수 없습니다."),

--- a/src/test/java/com/sprint/deokhugamteam7/domain/book/service/BookServiceUnitTest.java
+++ b/src/test/java/com/sprint/deokhugamteam7/domain/book/service/BookServiceUnitTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,7 +43,6 @@ public class BookServiceUnitTest {
     // given
     LocalDate now = LocalDate.now();
     BookCreateRequest request = new BookCreateRequest("aaa", "bbb", null, "ccc", now, "123");
-    when(bookRepository.existsByIsbn(request.isbn())).thenReturn(false);
     // when
     BookDto bookDto = bookService.create(request, null);
     // then
@@ -81,7 +81,9 @@ public class BookServiceUnitTest {
     // given
     LocalDate now = LocalDate.now();
     BookCreateRequest request = new BookCreateRequest("aaa", "bbb", "ccc", "ddd", now, "1234567");
-    when(bookRepository.existsByIsbn("1234567")).thenReturn(true);
+    Book mock = spy(Book.class);
+    mock.setIsDeleted(true);
+    when(bookRepository.findByIsbn("1234567")).thenReturn(Optional.of(mock));
     // when & then
     assertThrows(DeokhugamException.class, ()->
         bookService.create(request, mock(MockMultipartFile.class)));


### PR DESCRIPTION
## 📚 PR 요약: ISBN 처리 개선 · switch 식 리팩터링 · 테스트 업데이트

이번 Pull Request는 `Book` 도메인을 중심으로 **ISBN 중복 처리 개선**, **코드 현대화(switch expression)**, **테스트 정비** 등을 통해 전반적인 안정성과 가독성을 높입니다.

---

### 🔍 리팩터링 및 ISBN 처리 로직 개선

* **`existsByIsbn` → `findByIsbn` 교체**
  - ISBN 중복 검사 시, `existsByIsbn` 대신 `findByIsbn`를 사용하여 삭제된 도서 여부까지 판단 가능
  - 이미 삭제된 ISBN이면 해당 도서를 복구하는 로직 추가
  - 🔗 변경: [[1]](diffhunk://#diff-ffb5cf233d69dbff043a55309f6fa0817b5b0ddc625b9e6b06d29332c11a27c5L14-R14)

* **에러 코드 명확화**
  - 중복 ISBN에 대해 `INVALID_BOOK_REGISTER` 대신 새 에러 코드 **`DUPLICATE_ISBN`** 사용  
  → 예외 상황을 명확하게 구분

---

### 💡 코드 현대화: switch expression 적용

* 전통적인 `switch` 문을 Java의 **표현식 기반 `switch` 문법**으로 변경  
  → 가독성 향상, boilerplate 제거
  - 적용 파일:
    - `RankingBookProcessor.java`: [[1]](diffhunk://#diff-19370efb8d5d44fc8ad2119655f472fe75676a505885d0845aab26234f9d0830L42-R42)
    - `CursorPageResponseBookDto.java`: [[2]](diffhunk://#diff-14f0cbcad77bf2dc9b8df50ca26b8a4490a92aa13a547b5500634d3acacd003bL34-R40)
    - `RankingBookRepositoryImpl.java`: [[3]](diffhunk://#diff-acc684af0cbbe366e99af932d5377b51cd467ba227c2d802df6553bfc47efa93L121-R127)

---

### 🧪 테스트 코드 정비

* **ISBN 처리 변경에 따른 단위 테스트 수정**
  - `BookServiceUnitTest`에서 `findByIsbn` 기반 로직에 맞게 mocking 및 기대 결과 변경
  - 삭제된 도서 재등록 케이스 추가
  - 🔗 예시: [[1]](diffhunk://#diff-77eee6ea954363e54c781e30e99b66c8d37baa1101449ff6cd35cd4abb078dc5L45)

---

### 🧼 기타 사소한 정리

* `BasicBookService`에 `Optional` import 추가 (null 안전성 강화 목적)
* `BookCreateRequest` 내 불필요한 빈 줄 제거
