### PR TITLE
[선혜린 | 0615] 리뷰 content 앞/뒤 공백 제거 및 리뷰 검색 성능 향상을 위한 GIN + pg_trgm 인덱스 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 ---
 
 ## 팀원별 구현 기능 상세
+
 ### **김태우**
 
 (자신이 개발한 기능에 대한 사진이나 gif 파일 첨부)
@@ -48,9 +49,10 @@
 (자신이 개발한 기능에 대한 사진이나 gif 파일 첨부)
 
 - **리뷰 관리 API**
-    - Query DSL을 활용한 리뷰 정보의 CRUD 처리(Spring Data JPA 사용).
+    - Query DSL, GIN Index를 활용한 리뷰 정보의 CRUD 처리(Spring Data JPA 사용).
+    - 리뷰 좋아요 등록/취소 구현.
 - **인기 리뷰 API**
-    - Spring Batch, Schedule을 활용한 정기적인 배치 시스템 구현. 
+    - Spring Batch, Schedule을 활용한 정기적인 배치 시스템 구현.
     - 리뷰의 좋아요 수, 댓글 수에 따른 기간별(일간, 주간, 월간, 역대) 리뷰 점수를 구하여 인기 리뷰 구현.
 
 ### **이종원**
@@ -72,7 +74,7 @@
 - **사용자 관리 API**
     - 사용자 정보의 CRUD 처리(Spring Data JPA 사용)
 - **파워 유저 API**
-    - Spring Batch, Schedule을 활용한 정기적인 배치 시스템 구현. 
+    - Spring Batch, Schedule을 활용한 정기적인 배치 시스템 구현.
     - 기간별(일간, 주간, 월간, 역대) 활동 점수에 따른 파워 유저 순위 구현.
 
 ### **한성태**
@@ -92,6 +94,7 @@
 ---
 
 ## **파일 구조**
+
 <details>
 <summary>📁 프로젝트 파일 구조</summary>
 <div markdown="1">

--- a/src/main/java/com/sprint/deokhugamteam7/domain/review/service/BasicReviewService.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/review/service/BasicReviewService.java
@@ -71,7 +71,7 @@ public class BasicReviewService implements ReviewService {
     List<RankingBook> rankingBooks = book.getRankingBooks();
     rankingBooks.forEach(rankingBook -> rankingBook.update(request.rating(), false));
 
-    Review review = Review.create(book, user, request.content(), request.rating());
+    Review review = Review.create(book, user, request.content().trim(), request.rating());
     reviewRepository.save(review);
 
     return ReviewDto.of(review, 0, 0, false);
@@ -93,7 +93,7 @@ public class BasicReviewService implements ReviewService {
 
     review.validateUserAuthorization(userId);
 
-    String newContent = request.content();
+    String newContent = request.content().trim();
     int newRating = request.rating();
 
     review.update(newContent, newRating);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -204,3 +204,16 @@ CREATE TABLE if not exists BATCH_JOB_EXECUTION_CONTEXT
 CREATE SEQUENCE if not exists BATCH_STEP_EXECUTION_SEQ MAXVALUE 9223372036854775807 NO CYCLE;
 CREATE SEQUENCE if not exists BATCH_JOB_EXECUTION_SEQ MAXVALUE 9223372036854775807 NO CYCLE;
 CREATE SEQUENCE if not exists BATCH_JOB_SEQ MAXVALUE 9223372036854775807 NO CYCLE;
+
+-- trigram 기반 검색 기능 활성화
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- LIKE 최적화 위한 인덱스 생성.
+CREATE INDEX CONCURRENTLY if not exists reviews_content_trgm_idx
+    ON reviews USING gin (lower(content) gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY if not exists users_nickname_trgm_idx
+    ON users USING gin (lower(nickname) gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY if not exists books_title_trgm_idx
+    ON books USING gin (lower(title) gin_trgm_ops);


### PR DESCRIPTION
무엇을 구현했는가?
- 리뷰 content에 "     리뷰     "이 들어왔을 때, trim()을 적용해 앞/뒤 공백을 제거하여 "리뷰"가 저장되도록 하였습니다.

- 리뷰 검색 조건에서 LIKE 검색이 사용되는 content, nickname, title 컬럼에 대해 GIN + pg_trgm 인덱스를 추가하여 검색 성능을 최적화하였습니다.
또한, 인덱스 활성화를 위해 schema.sql에 CREATE EXTENSION pg_trgm 명령어를 포함했습니다.

- README.md - 구현 기능 상세 변경

왜 이 작업이 필요한가?
기존의 LIKE '%keyword%' 방식은 인덱스를 타지 못해 전체 테이블을 탐색하는 Seq Scan이 발생합니다. 특히 데이터량이 많아지고, 선택도가 낮은(즉, 많은 row가 검색되는) 경우 심각한 성능 저하로 이어집니다.
이에 pg_trgm 기반의 GIN 인덱스를 활용하면 LIKE '%...%' 패턴조차도 효율적으로 인덱스를 탈 수 있어 성능을 크게 개선할 수 있습니다.

🔍 주요 변경 사항 (What was changed)
schema.sql에 pg_trgm 확장 및 GIN 인덱스 생성 명령 추가:
```
CREATE EXTENSION IF NOT EXISTS pg_trgm;

CREATE INDEX CONCURRENTLY IF NOT EXISTS reviews_content_trgm_idx
  ON reviews USING gin (lower(content) gin_trgm_ops);

CREATE INDEX CONCURRENTLY IF NOT EXISTS users_nickname_trgm_idx
  ON users USING gin (lower(nickname) gin_trgm_ops);

CREATE INDEX CONCURRENTLY IF NOT EXISTS books_title_trgm_idx
  ON books USING gin (lower(title) gin_trgm_ops);
```

🧩 설계 및 구현 고려사항 (Design decisions)
왜 GIN + pg_trgm인가?
PostgreSQL 공식 문서 §14.4에 따르면, LIKE 또는 ILIKE 검색의 성능은 다음과 같이 개선됩니다:

“For pattern matching queries with LIKE, ILIKE, or SIMILAR TO, pg_trgm indexes can reduce query latency from O(N) to near O(log N) complexity.”

즉, 수천~수만 건 이상의 데이터 중 일부를 검색하거나, 다수의 조건이 일치하는 경우 성능 차이가 수십 배까지 벌어질 수 있습니다.

왜 CONCURRENTLY 옵션을 사용했는가?
운영 중인 DB에 직접 인덱스를 추가해야 하므로, DDL로 인한 테이블 Lock을 방지하기 위해 CREATE INDEX CONCURRENTLY를 사용하였습니다.

데이터가 적은 경우에는?
데이터 수가 적거나 전체 스캔 비용이 낮을 경우, 옵티마이저는 여전히 Seq Scan을 선택할 수 있습니다. 따라서 이 인덱스는 대량의 리뷰가 누적될 미래 상황에 대비한 설계이며, 지금은 성능 차이가 체감되지 않을 수 있습니다.

