### PR TITLE
[0616] fix: StepScope 제외로 인해 Ranking 적용 안된 오류 수정

### DIFF
--- a/src/main/java/com/sprint/deokhugamteam7/domain/book/batch/step/RankingBookWriter.java
+++ b/src/main/java/com/sprint/deokhugamteam7/domain/book/batch/step/RankingBookWriter.java
@@ -3,12 +3,14 @@ package com.sprint.deokhugamteam7.domain.book.batch.step;
 import com.sprint.deokhugamteam7.domain.book.entity.RankingBook;
 import com.sprint.deokhugamteam7.domain.book.repository.RankingBookRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@StepScope
 public class RankingBookWriter implements ItemWriter<RankingBook> {
   private final RankingBookRepository rankingBookRepository;
 


### PR DESCRIPTION
이 풀 요청은 'RankingBookWriter' 클래스에 작지만 중요한 변경 사항을 도입합니다. 변경 사항에는 '@StepScope' 주석이 추가되어 스프링 배치가 단계 실행 중에 이 구성 요소의 범위를 동적으로 관리할 수 있습니다.

버전 수정 1.0.7